### PR TITLE
Docsify: fixed external link problem

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
 
               var link = 
                 href.startsWith('#') ? // a hash link
-                  hash + '?id=' + href.split('#')[1]
+                  hash.replace(new RegExp('\\?id=.*'),'') + '?id=' + href.split('#')[1]
                 :
                   dir === '' ? // the root page is a special case since it's not in `docs`
                     href.replace('docs/','')


### PR DESCRIPTION
This fixes a problem pointed out by @Alonski 👍 
clicking on an external link and then going back breaks hash links.