### PR TITLE
Bump version to alpha-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/daostack/arc.svg?branch=master)](https://travis-ci.org/daostack/arc)
-[![NPM Package](https://img.shields.io/npm/v/daostack-arc.svg?style=flat-square)](https://www.npmjs.org/package/daostack-arc)
+[![NPM Package](https://img.shields.io/npm/v/@daostack/arc.svg?style=flat-square)](https://www.npmjs.org/package/@daostack/arc)
 # Arc
 
 Arc is the lower layer of the DAO stack. It consists a set of smart contracts deployed on the Ethereum blockchain that define the basic building blocks and standard components that can be used to implement any DAO.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daostack-arc",
-  "version": "0.0.0-alpha.27",
+  "version": "0.0.0-alpha.28",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "daostack-arc",
-  "version": "0.0.0-alpha.28",
+  "name": "@daostack/arc",
+  "version": "0.0.0-alpha.29",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",


### PR DESCRIPTION
So it will be aligned to : https://www.npmjs.com/package/@daostack/arc

Update root readme to point to the right npm package.