### PR TITLE
Genesisprotocol : Make it YES/NO voting only

### DIFF
--- a/contracts/VotingMachines/AbsoluteVote.sol
+++ b/contracts/VotingMachines/AbsoluteVote.sol
@@ -206,15 +206,13 @@ contract AbsoluteVote is IntVoteInterface {
     }
 
     /**
-     * @dev votesStatus returns the number of yes, no, and abstain and if the proposal is ended of a given proposal id
+     * @dev voteStatus returns the reputation voted for a proposal for a specific voting choice.
      * @param _proposalId the ID of the proposal
-     * @return votes array of votes for each choice
+     * @param _choice the index in the
+     * @return voted reputation for the given choice
      */
-    function votesStatus(bytes32 _proposalId) public view returns(uint[11] votes) {
-        Proposal storage proposal = proposals[_proposalId];
-        for (uint cnt = 0; cnt <= proposal.numOfChoices; cnt++) {
-            votes[cnt] = proposal.votes[cnt];
-        }
+    function voteStatus(bytes32 _proposalId,uint _choice) public view returns(uint) {
+        return proposals[_proposalId].votes[_choice];
     }
 
     /**

--- a/contracts/VotingMachines/AbsoluteVote.sol
+++ b/contracts/VotingMachines/AbsoluteVote.sol
@@ -233,7 +233,7 @@ contract AbsoluteVote is IntVoteInterface {
         CancelVoting(_proposalId, _voter);
     }
 
-    function deleteProposal(bytes32 _proposalId) private {
+    function deleteProposal(bytes32 _proposalId) internal {
         Proposal storage proposal = proposals[_proposalId];
         for (uint cnt = 0; cnt <= proposal.numOfChoices; cnt++) {
             delete proposal.votes[cnt];

--- a/contracts/VotingMachines/IntVoteInterface.sol
+++ b/contracts/VotingMachines/IntVoteInterface.sol
@@ -50,4 +50,12 @@ contract IntVoteInterface {
     function getNumberOfChoices(bytes32 _proposalId) public view returns(uint);
 
     function isVotable(bytes32 _proposalId) public view returns(bool);
+
+    /**
+     * @dev voteStatus returns the reputation voted for a proposal for a specific voting choice.
+     * @param _proposalId the ID of the proposal
+     * @param _choice the index in the
+     * @return voted reputation for the given choice
+     */
+    function voteStatus(bytes32 _proposalId,uint _choice) public view returns(uint);
 }

--- a/contracts/VotingMachines/QuorumVote.sol
+++ b/contracts/VotingMachines/QuorumVote.sol
@@ -28,7 +28,7 @@ contract QuorumVote is IntVoteInterface, AbsoluteVote {
                 }
             }
             Proposal memory tmpProposal = proposal;
-            delete proposals[_proposalId];
+            deleteProposal(_proposalId);
             ExecuteProposal(_proposalId, maxInd);
             (tmpProposal.executable).execute(_proposalId, tmpProposal.avatar, int(maxInd));
             return true;

--- a/contracts/test/GenesisProtocolFormulasMock.sol
+++ b/contracts/test/GenesisProtocolFormulasMock.sol
@@ -15,7 +15,7 @@ contract GenesisProtocolFormulasMock is GenesisProtocolFormulasInterface {
     function shouldBoost(bytes32 _proposalId) public view returns(bool) {
         address avatar;
         avatar = GenesisProtocol(msg.sender).proposalAvatar(_proposalId);
-        int score = int(GenesisProtocol(msg.sender).voteStake(_proposalId,1)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,0));
+        int score = int(GenesisProtocol(msg.sender).voteStake(_proposalId,2)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,1));
         return (score >= threshold(avatar));
     }
 
@@ -25,17 +25,7 @@ contract GenesisProtocolFormulasMock is GenesisProtocolFormulasInterface {
      * @return uint proposal score.
      */
     function score(bytes32 _proposalId) public view returns (int) {
-        uint numOfChoices = GenesisProtocol(msg.sender).getNumberOfChoices(_proposalId);
-        if (numOfChoices == 2) {
-            return int(GenesisProtocol(msg.sender).voteStake(_proposalId,1)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,0));
-        } else {
-            uint totalStakes;
-            uint totalVotes;
-            uint votersStakes;
-            (totalVotes,totalStakes,votersStakes) = GenesisProtocol(msg.sender).proposalStatus(_proposalId);
-            uint totalReputationSupply = GenesisProtocol(msg.sender).totalReputationSupply(_proposalId);
-            return int(((totalStakes + votersStakes) * (totalVotes**2))/(totalReputationSupply**2));
-      }
+        return int(GenesisProtocol(msg.sender).voteStake(_proposalId,2)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,1));
     }
 
     /**

--- a/contracts/test/GenesisProtocolFormulasMock.sol
+++ b/contracts/test/GenesisProtocolFormulasMock.sol
@@ -15,7 +15,7 @@ contract GenesisProtocolFormulasMock is GenesisProtocolFormulasInterface {
     function shouldBoost(bytes32 _proposalId) public view returns(bool) {
         address avatar;
         avatar = GenesisProtocol(msg.sender).proposalAvatar(_proposalId);
-        int score = int(GenesisProtocol(msg.sender).voteStake(_proposalId,2)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,1));
+        int score = int(GenesisProtocol(msg.sender).voteStake(_proposalId,GenesisProtocol(msg.sender).YES())) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,GenesisProtocol(msg.sender).NO()));
         return (score >= threshold(avatar));
     }
 
@@ -25,7 +25,7 @@ contract GenesisProtocolFormulasMock is GenesisProtocolFormulasInterface {
      * @return uint proposal score.
      */
     function score(bytes32 _proposalId) public view returns (int) {
-        return int(GenesisProtocol(msg.sender).voteStake(_proposalId,2)) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,1));
+        return int(GenesisProtocol(msg.sender).voteStake(_proposalId,GenesisProtocol(msg.sender).YES())) - int(GenesisProtocol(msg.sender).voteStake(_proposalId,GenesisProtocol(msg.sender).NO()));
     }
 
     /**

--- a/test/absolutevote.js
+++ b/test/absolutevote.js
@@ -49,28 +49,7 @@ const checkProposalInfo = async function(proposalId, _proposalInfo) {
 };
 
 const checkVotesStatus = async function(proposalId, _votesStatus){
-  let votesStatus;
-  votesStatus = await absoluteVote.votesStatus(proposalId);
-  // uint Option 1
-  assert.equal(votesStatus[0], _votesStatus[0]);
-  // uint Option 2
-  assert.equal(votesStatus[1], _votesStatus[1]);
-  // uint Option 3
-  assert.equal(votesStatus[2], _votesStatus[2]);
-  // uint Option 4
-  assert.equal(votesStatus[3], _votesStatus[3]);
-  // uint Option 5
-  assert.equal(votesStatus[4], _votesStatus[4]);
-  // uint Option 6
-  assert.equal(votesStatus[5], _votesStatus[5]);
-  // uint Option 7
-  assert.equal(votesStatus[6], _votesStatus[6]);
-  // uint Option 8
-  assert.equal(votesStatus[7], _votesStatus[7]);
-  // uint Option 9
-  assert.equal(votesStatus[8], _votesStatus[8]);
-  // uint Option 10
-  assert.equal(votesStatus[9], _votesStatus[9]);
+  return helpers.checkVotesStatus(proposalId, _votesStatus,absoluteVote);
 };
 
 const checkIsVotable = async function(proposalId, _votable){
@@ -98,28 +77,7 @@ const checkIsVotableWithAbsoluteVote = async function(proposalId, _votable,absol
 };
 
 const checkVotesStatusWithAbsoluteVote = async function(proposalId, _votesStatus, absoluteVote){
-  let votesStatus;
-  votesStatus = await absoluteVote.votesStatus(proposalId);
-  // uint Option 1
-  assert.equal(votesStatus[0], _votesStatus[0]);
-  // uint Option 2
-  assert.equal(votesStatus[1], _votesStatus[1]);
-  // uint Option 3
-  assert.equal(votesStatus[2], _votesStatus[2]);
-  // uint Option 4
-  assert.equal(votesStatus[3], _votesStatus[3]);
-  // uint Option 5
-  assert.equal(votesStatus[4], _votesStatus[4]);
-  // uint Option 6
-  assert.equal(votesStatus[5], _votesStatus[5]);
-  // uint Option 7
-  assert.equal(votesStatus[6], _votesStatus[6]);
-  // uint Option 8
-  assert.equal(votesStatus[7], _votesStatus[7]);
-  // uint Option 9
-  assert.equal(votesStatus[8], _votesStatus[8]);
-  // uint Option 10
-  assert.equal(votesStatus[9], _votesStatus[9]);
+  return helpers.checkVotesStatus(proposalId, _votesStatus,absoluteVote);
 };
 
 const checkProposalInfoWithAbsoluteVote = async function(proposalId, _proposalInfo, absoluteVote) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -166,6 +166,16 @@ export const checkVoteInfo = async function(absoluteVote,proposalId, voterAddres
 };
 
 
+export const checkVotesStatus = async function(proposalId, _votesStatus,votingMachine){
+
+  let voteStatus;
+  for (var i = 0; i < _votesStatus.length; i++) {
+      voteStatus = await votingMachine.voteStatus(proposalId,i);
+      assert.equal(voteStatus, _votesStatus[i]);
+  }
+};
+
+
 // Increases testrpc time by the passed duration in seconds
 export const increaseTime = async function(duration) {
   const id = Date.now();


### PR DESCRIPTION
- Currently there is only  YES/NO voting choices. (NUM_OF_CHOICES is 2).
- Abstain (0) - cannot be voted.
- properly delete proposal on quorum vote.
- VotesStatus interface function changed to VoteStatus.  
