### PR TITLE
avatar : revert if delegatecall return false

### DIFF
--- a/contracts/controller/Avatar.sol
+++ b/contracts/controller/Avatar.sol
@@ -58,10 +58,12 @@ contract Avatar is Ownable {
     {
         GenericAction(_action, _params);
         // solium-disable-next-line security/no-low-level-calls
-        return _action.delegatecall(bytes4(keccak256("action(bytes32[])")),
+        bool ret = _action.delegatecall(bytes4(keccak256("action(bytes32[])")),
         uint256(32),// length of length of the array
         uint256(_params.length), // length of the array
         _params);                 // array itself);
+        require(ret);
+        return ret;
     }
 
     /**

--- a/contracts/controller/Avatar.sol
+++ b/contracts/controller/Avatar.sol
@@ -57,13 +57,15 @@ contract Avatar is Ownable {
     public onlyOwner returns(bool)
     {
         GenericAction(_action, _params);
-        // solium-disable-next-line security/no-low-level-calls
-        bool ret = _action.delegatecall(bytes4(keccak256("action(bytes32[])")),
-        uint256(32),// length of length of the array
-        uint256(_params.length), // length of the array
-        _params);                 // array itself);
-        require(ret);
-        return ret;
+        require(
+          // solium-disable-next-line security/no-low-level-calls
+            _action.delegatecall(
+                bytes4(keccak256("action(bytes32[])")),
+                uint256(32),// length of length of the array
+                uint256(_params.length), // length of the array
+                _params)
+        );                 // array itself);
+        return true;
     }
 
     /**

--- a/contracts/controller/Avatar.sol
+++ b/contracts/controller/Avatar.sol
@@ -63,8 +63,8 @@ contract Avatar is Ownable {
                 bytes4(keccak256("action(bytes32[])")),
                 uint256(32),// length of length of the array
                 uint256(_params.length), // length of the array
-                _params)
-        );                 // array itself);
+                _params) // array itself
+        );
         return true;
     }
 

--- a/contracts/test/ActionMock.sol
+++ b/contracts/test/ActionMock.sol
@@ -9,6 +9,8 @@ contract ActionMock is ActionInterface {
 
     function action(bytes32[] params) public returns(bool) {
         Action(msg.sender,params[0]);
+        if (params[0] == 0x1234000000000000000000000000000000000000000000000000000000000000)
+            revert();
         return true;
     }
 

--- a/test/avatar.js
+++ b/test/avatar.js
@@ -35,6 +35,19 @@ contract('Avatar', function (accounts)  {
         assert.equal(tx.logs[0].args._param, "0x4567000000000000000000000000000000000000000000000000000000000000");
     });
 
+    it("generic call should revert if action revert", async () => {
+        avatar = await setup();
+        let action = await ActionMock.new();
+        await avatar.transferOwnership(action.address);
+        try{
+           await action.genericAction(avatar.address,[0x1234]);
+           assert(false,"generic call should revert if action revert ");
+          }
+          catch(ex){
+          helpers.assertVMException(ex);
+        }
+    });
+
     it("pay ether to avatar", async () => {
         avatar = await setup();
         web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.toWei('1', "ether")});


### PR DESCRIPTION
Due to the fact that delegatecall method never throw an exception, but will return false if the call encounters an exception.