### PR TITLE
Moved `zeppelin-solidity` to deps, moved `cross-conf-env` to devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1708,6 +1708,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cross-conf-env/-/cross-conf-env-1.1.2.tgz",
       "integrity": "sha1-7dlr//SOTO2w90HMpSeI9ks65kA=",
+      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0"
       }
@@ -1716,6 +1717,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -1954,8 +1956,7 @@
     "dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-      "dev": true
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -4405,8 +4406,7 @@
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-number": {
       "version": "2.1.0",
@@ -4513,7 +4513,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -4543,8 +4544,7 @@
     "js-sha3": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
-      "dev": true
+      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -4899,6 +4899,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -5288,7 +5289,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -5297,8 +5297,7 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
       }
     },
@@ -5904,7 +5903,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.0",
@@ -6581,6 +6581,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -6588,7 +6589,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.1",
@@ -7017,7 +7019,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
@@ -7969,6 +7970,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -8108,7 +8110,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yamljs": {
       "version": "0.3.0",
@@ -8239,7 +8242,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.6.0.tgz",
       "integrity": "sha512-OYv0QeEy2h5Esiz7/8vMpywTPDiAS0LSTbca5q0+xEDDSwP/uy2fhAguP7heLDelorf9gMxLMLBrGbn/2xBEMQ==",
-      "dev": true,
       "requires": {
         "dotenv": "4.0.0",
         "ethjs-abi": "0.2.1"
@@ -8248,14 +8250,12 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "ethjs-abi": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
           "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "js-sha3": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "bignumber.js": "^5.0.0",
+    "cross-conf-env": "^1.1.2",
     "default-options": "^1.0.0",
     "eslint": "^4.17.0",
     "eslint-config-defaults": "^9.0.0",
@@ -62,8 +63,7 @@
     "web3-typescript-typings": "^0.9.8",
     "web3-utils": "^1.0.0-beta.29",
     "when": "^3.7.8",
-    "yargs": "^11.0.0",
-    "zeppelin-solidity": "^1.6.0"
+    "yargs": "^11.0.0"
   },
   "repository": {
     "type": "git",
@@ -88,6 +88,6 @@
   },
   "homepage": "https://daostack.io",
   "dependencies": {
-    "cross-conf-env": "^1.1.2"
+    "zeppelin-solidity": "1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "pug": "^2.0.0-rc.4",
     "rimraf": "^2.6.2",
     "run-with-ganache": "^0.1.1",
-    "shelljs": "^0.8.1",
     "solc": "^0.4.19",
     "solc-cli": "^0.3.0",
     "solium": "^1.1.3",
@@ -62,8 +61,7 @@
     "uint32": "^0.2.1",
     "web3-typescript-typings": "^0.9.8",
     "web3-utils": "^1.0.0-beta.29",
-    "when": "^3.7.8",
-    "yargs": "^11.0.0"
+    "when": "^3.7.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since we want users to import `.sol` contracts and compile them from source, we need to have `zeppelin-solidity` as a dep and not devDep, otherwise users would not be able to compile.

Also `cross-conf-env` should be a devDep.

**Please republish npm package after merging this PR.**