### PR TITLE
Remove an Unnecessary Import

### DIFF
--- a/contracts/controller/Avatar.sol
+++ b/contracts/controller/Avatar.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.19;
 
-import "./Controller.sol";
 import "./Reputation.sol";
 import "./DAOToken.sol";
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";


### PR DESCRIPTION
This changes removes the import of Controller from the Avatar. This 
import seems to be unused as Controller is never referenced within
Avatar. Additionally, the circular dependency between Avatar and
Controller can be eliminated by removing this import.

All tests pass.