### PR TITLE
Fix 404 issue on `https://daostack.github.io/arc`: auto redirect `/` to `/README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We take no responsibility for your implementation decisions and any security pro
     }
     ```
     You should be able to find all `@daostack/arc` already built contracts (<contract>.json) ready for deployment under `node_modules/@daostack/arc/build/contracts/` folder.
-4. Read the [documentation](https://daostack.github.io/arc/README) to get a better understanding of how to use Arc.
+4. Read the [documentation](https://daostack.github.io/arc/) to get a better understanding of how to use Arc.
 
 ## Contribute
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<!--redirect to /README-->
+<html>
+  <head><meta http-equiv="refresh" content="0; URL='README'" /></head>
+  <body></body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,10 @@
 site_name: DAOstack Arc Docs
-site_url: https://daostack.github.io/arc/README
 repo_url: https://github.com/daostack/arc/
 repo_name: daostack/arc
 site_description: A platform for building DAOs
 docs_dir: docs
+extra_templates:
+- index.html
 markdown_extensions:
 - admonition
 - codehilite:


### PR DESCRIPTION
going to `https://daostack.github.io/arc/README` was fine, but going to `https://daostack.github.io/arc` gives a bunch of 404 issues.

New version deploy to `gh-pages`.