### PR TITLE
Absolutevote : add refreshReputation function

### DIFF
--- a/contracts/VotingMachines/AbsoluteVote.sol
+++ b/contracts/VotingMachines/AbsoluteVote.sol
@@ -248,7 +248,8 @@ contract AbsoluteVote is IntVoteInterface {
             Voter storage voter = proposal.voters[_voters[i]];
              //check that the voters already votes.
             if (voter.reputation > 0) {
-                //if the reputation change..so update.
+                //update only if there is a mismatch between the voter's system reputation
+                //and the reputation stored in the voting machine for the voter.
                 uint rep = params.reputationSystem.reputationOf(_voters[i]);
                 if (rep > voter.reputation) {
                     proposal.votes[voter.vote] = proposal.votes[voter.vote].add(rep - voter.reputation);
@@ -263,6 +264,7 @@ contract AbsoluteVote is IntVoteInterface {
                 }
              }
         }
+        return true;
     }
 
     function cancelVoteInternal(bytes32 _proposalId, address _voter) internal {

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -80,7 +80,7 @@ module.exports = async function(deployer) {
                           simpleICOInst.address,
                           contributionRewardInst.address];
       const paramsArray = [schemeRegisterParams, schemeGCRegisterParams, schemeUpgradeParams,simpleICOParams,contributionRewardParams];
-      const permissionArray = ['0x0000001F', '0x00000005', '0x00000009','0x00000001','0x00000001'];
+      const permissionArray = ['0x0000001F', '0x00000005', '0x0000000a','0x00000001','0x00000001'];
 
       // set DAOstack initial schmes:
       await daoCreatorInst.setSchemes(

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -31,7 +31,7 @@ const setup = async function (accounts) {
    testSetup.vestingSchemeParams= await setupVestingSchemeParams(testSetup.vestingScheme);
    //give some tokens to organization avatar so it could register the universal scheme.
    await testSetup.standardTokenMock.transfer(testSetup.org.avatar.address,30,{from:accounts[1]});
-   var permissions = "0x0000000F";
+   var permissions = "0x000000001";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.vestingScheme.address],[testSetup.vestingSchemeParams.paramsHash],[permissions]);
 
    return testSetup;


### PR DESCRIPTION
- Add refreshReputation function can be called by one to refresh the reputation votes for a given proposal and list of voters during voting process. 

- Correct vesting and upgrade schemes permission at test and test migration script.

