### PR TITLE
make ContributionReward handle multiple beneficiaries, scripts work in Windows

### DIFF
--- a/contracts/universalSchemes/ContributionReward.sol
+++ b/contracts/universalSchemes/ContributionReward.sol
@@ -132,10 +132,13 @@ contract ContributionReward is UniversalScheme {
 
         bytes32 contributionId = controllerParams.intVote.propose(2, controllerParams.voteApproveParams, _avatar, ExecutableInterface(this),msg.sender);
 
+        address[] memory beneficiaries;
         // Check beneficiary is not null:
         if (_beneficiaries.length == 0) {
-            _beneficiaries = new address[](1);
-            _beneficiaries[0] = msg.sender;
+            beneficiaries = new address[](1);
+            beneficiaries[0] = msg.sender;
+        } else {
+            beneficiaries = _beneficiaries;
         }
 
         // Set the struct:
@@ -146,7 +149,7 @@ contract ContributionReward is UniversalScheme {
             ethReward: _rewards[1],
             externalToken: _externalToken,
             externalTokenReward: _rewards[2],
-            beneficiaries: _beneficiaries,
+            beneficiaries: beneficiaries,
             periodLength: _rewards[3],
             numberOfPeriods: _rewards[4],
             executionTime: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -829,6 +829,12 @@
       "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
       "dev": true
     },
+    "babel-plugin-syntax-do-expressions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
+      "dev": true
+    },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
@@ -851,6 +857,12 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -921,6 +933,16 @@
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-do-expressions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.22.0.tgz",
+      "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-do-expressions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1188,6 +1210,16 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-function-bind": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
@@ -1266,6 +1298,17 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0"
+      }
+    },
+    "babel-preset-stage-0": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
+      "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-do-expressions": "6.22.0",
+        "babel-plugin-transform-function-bind": "6.22.0",
+        "babel-preset-stage-1": "6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -2136,15 +2179,6 @@
         "moment-timezone": "0.5.14"
       }
     },
-    "cross-conf-env": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cross-conf-env/-/cross-conf-env-1.1.2.tgz",
-      "integrity": "sha1-7dlr//SOTO2w90HMpSeI9ks65kA=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2154,6 +2188,19 @@
         "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
+      }
+    },
+    "cross-var": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cross-var/-/cross-var-1.1.0.tgz",
+      "integrity": "sha1-8PDUuyNdlRONGlOYQtKQ8A23HNY=",
+      "dev": true,
+      "requires": {
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-register": "6.26.0",
+        "cross-spawn": "5.1.0",
+        "exit": "0.1.2"
       }
     },
     "cryptiles": {

--- a/package.json
+++ b/package.json
@@ -1,91 +1,91 @@
 {
-  "name": "@daostack/arc",
-  "version": "0.0.0-alpha.38",
-  "description": "A platform for building DAOs",
-  "files": [
-    "contracts/",
-    "docs/",
-    "build/contracts/",
-    "migrations/",
-    "test/",
-    "truffle.js",
-    "tsconfig.json"
-  ],
-  "config": {
-    "gasLimit": "5400000"
-  },
-  "scripts": {
-    "test": "cross-conf-env run-with-ganache --ganache-cmd ganache-cli --gasLimit npm_package_config_gasLimit 'npm run truffle compile && npm run truffle migrate && npm run truffle test'",
-    "ganache": "cross-conf-env ganache-cli -l npm_package_config_gasLimit --account=\"0x0191ecbd1b150b8a3c27c27010ba51b45521689611e669109e034fd66ae69621,9999999999999999999999999999999999999999999\" --account=\"0x00f360233e89c65970a41d4a85990ec6669526b2230e867c352130151453180d,9999999999999999999999999999999999999999999\" --account=\"0x987a26abca7432016104ce2f24ce639340e25afe06ac69f68791399e7a5d1028,9999999999999999999999999999999999999999999\" --account=\"0x89af34b1b7347834048b99423dad174a14bf14540d720d72c16ae92e94b987cb,9999999999999999999999999999999999999999999\" --account=\"0xc867be647eb2bc51e4c0d61066859875cf3634fe949b6f5f85c69ab90e485b37,9999999999999999999999999999999999999999999\" --account=\"0xefabcc2377dee5e51b5a9e65a3854aec85fbbec3cb584d8ad4f9679869fb33c6,9999999999999999999999999999999999999999999\"",
-    "start": "pm2 start truffle -- serve",
-    "lint": "eslint .",
-    "lint --fix": "eslint --fix .",
-    "solium": "solium --dir ./contracts/",
-    "truffle": "truffle",
-    "build": "rimraf build && truffle compile",
-    "docs:update": "soldoc -q -o docs/generated_docs",
-    "docs:build": "soldoc -q -o docs/generated_docs && mkdocs build",
-    "docs:deploy": "soldoc -q -o docs/generated_docs && mkdocs gh-deploy --force",
-    "docs:preview": "soldoc -q -o docs/generated_docs && mkdocs serve"
-  },
-  "devDependencies": {
-    "@soldoc/soldoc": "^0.4.3",
-    "babel-cli": "^6.26.0",
-    "babel-eslint": "^8.2.1",
-    "babel-plugin-syntax-async-functions": "^6.13.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-register": "^6.26.0",
-    "bignumber.js": "^5.0.0",
-    "cross-conf-env": "^1.1.2",
-    "default-options": "^1.0.0",
-    "eslint": "^4.17.0",
-    "eslint-config-defaults": "^9.0.0",
-    "eslint-config-standard": "^11.0.0-beta.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.6.1",
-    "eslint-plugin-standard": "^3.0.1",
-    "ganache-cli": "^6.1.0",
-    "pm2": "^2.9.3",
-    "promisify": "^0.0.3",
-    "pug": "^2.0.0-rc.4",
-    "rimraf": "^2.6.2",
-    "run-with-ganache": "^0.1.1",
-    "solc": "^0.4.19",
-    "solc-cli": "^0.3.0",
-    "solium": "^1.1.6",
-    "truffle": "^4.1.5",
-    "truffle-contract": "^3.0.4",
-    "uint32": "^0.2.1",
-    "web3-typescript-typings": "^0.9.8",
-    "web3-utils": "^1.0.0-beta.29",
-    "when": "^3.7.8"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/daostack/arc.git"
-  },
-  "keywords": [
-    "solidity",
-    "ethereum",
-    "smart",
-    "contracts",
-    "security",
-    "daostack",
-    "arc"
-  ],
-  "engines": {
-    "node": ">=9.3.0"
-  },
-  "author": "DAOstack (https://www.daostack.io)",
-  "license": "GPL-3.0",
-  "bugs": {
-    "url": "https://github.com/daostack/arc/issues"
-  },
-  "homepage": "https://daostack.io",
-  "dependencies": {
-    "zeppelin-solidity": "1.8.0"
-  }
+    "name": "@daostack/arc",
+    "version": "0.0.0-alpha.38",
+    "description": "A platform for building DAOs",
+    "files": [
+        "contracts/",
+        "docs/",
+        "build/contracts/",
+        "migrations/",
+        "test/",
+        "truffle.js",
+        "tsconfig.json"
+    ],
+    "config": {
+        "gasLimit": "5400000"
+    },
+    "scripts": {
+        "test": "cross-var run-with-ganache --ganache-cmd ganache-cli --gasLimit $npm_package_config_gasLimit 'npm run truffle compile && npm run truffle migrate && npm run truffle test'",
+        "ganache": "cross-var ganache-cli -l $npm_package_config_gasLimit --account=\"0x0191ecbd1b150b8a3c27c27010ba51b45521689611e669109e034fd66ae69621,9999999999999999999999999999999999999999999\" --account=\"0x00f360233e89c65970a41d4a85990ec6669526b2230e867c352130151453180d,9999999999999999999999999999999999999999999\" --account=\"0x987a26abca7432016104ce2f24ce639340e25afe06ac69f68791399e7a5d1028,9999999999999999999999999999999999999999999\" --account=\"0x89af34b1b7347834048b99423dad174a14bf14540d720d72c16ae92e94b987cb,9999999999999999999999999999999999999999999\" --account=\"0xc867be647eb2bc51e4c0d61066859875cf3634fe949b6f5f85c69ab90e485b37,9999999999999999999999999999999999999999999\" --account=\"0xefabcc2377dee5e51b5a9e65a3854aec85fbbec3cb584d8ad4f9679869fb33c6,9999999999999999999999999999999999999999999\"",
+        "start": "pm2 start truffle -- serve",
+        "lint": "eslint .",
+        "lint --fix": "eslint --fix .",
+        "solium": "solium --dir ./contracts/",
+        "truffle": "truffle",
+        "build": "rimraf build && truffle compile",
+        "docs:update": "soldoc -q -o docs/generated_docs",
+        "docs:build": "soldoc -q -o docs/generated_docs && mkdocs build",
+        "docs:deploy": "soldoc -q -o docs/generated_docs && mkdocs gh-deploy --force",
+        "docs:preview": "soldoc -q -o docs/generated_docs && mkdocs serve"
+    },
+    "devDependencies": {
+        "@soldoc/soldoc": "^0.4.3",
+        "babel-cli": "^6.26.0",
+        "babel-eslint": "^8.2.1",
+        "babel-plugin-syntax-async-functions": "^6.13.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-preset-es2015": "^6.24.1",
+        "babel-register": "^6.26.0",
+        "bignumber.js": "^5.0.0",
+        "cross-var": "^1.1.0",
+        "default-options": "^1.0.0",
+        "eslint": "^4.17.0",
+        "eslint-config-defaults": "^9.0.0",
+        "eslint-config-standard": "^11.0.0-beta.0",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-promise": "^3.6.0",
+        "eslint-plugin-react": "^7.6.1",
+        "eslint-plugin-standard": "^3.0.1",
+        "ganache-cli": "^6.1.0",
+        "pm2": "^2.9.3",
+        "promisify": "^0.0.3",
+        "pug": "^2.0.0-rc.4",
+        "rimraf": "^2.6.2",
+        "run-with-ganache": "^0.1.1",
+        "solc": "^0.4.19",
+        "solc-cli": "^0.3.0",
+        "solium": "^1.1.6",
+        "truffle": "^4.1.5",
+        "truffle-contract": "^3.0.4",
+        "uint32": "^0.2.1",
+        "web3-typescript-typings": "^0.9.8",
+        "web3-utils": "^1.0.0-beta.29",
+        "when": "^3.7.8"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/daostack/arc.git"
+    },
+    "keywords": [
+        "solidity",
+        "ethereum",
+        "smart",
+        "contracts",
+        "security",
+        "daostack",
+        "arc"
+    ],
+    "engines": {
+        "node": ">=9.3.0"
+    },
+    "author": "DAOstack (https://www.daostack.io)",
+    "license": "GPL-3.0",
+    "bugs": {
+        "url": "https://github.com/daostack/arc/issues"
+    },
+    "homepage": "https://daostack.io",
+    "dependencies": {
+        "zeppelin-solidity": "1.8.0"
+    }
 }

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -8,465 +8,501 @@ const Avatar = artifacts.require("./Avatar.sol");
 
 
 export class ContributionRewardParams {
-  constructor() {
-  }
+    constructor() {
+    }
 }
 
-const checkRedeemedPeriods = async function(
-                                            testSetup,
-                                            proposalId,
-                                            ReputationPeriod,
-                                            nativeTokenPeriod,
-                                            EtherPeriod,
-                                            ExternalTokenPeriod
-                                            ) {
-    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId,testSetup.org.avatar.address,0),ReputationPeriod);
-    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId,testSetup.org.avatar.address,1),nativeTokenPeriod);
-    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId,testSetup.org.avatar.address,2),EtherPeriod);
-    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId, testSetup.org.avatar.address,3),ExternalTokenPeriod);
+const checkRedeemedPeriods = async function (
+    testSetup,
+    proposalId,
+    ReputationPeriod,
+    nativeTokenPeriod,
+    EtherPeriod,
+    ExternalTokenPeriod
+) {
+    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId, testSetup.org.avatar.address, 0), ReputationPeriod);
+    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId, testSetup.org.avatar.address, 1), nativeTokenPeriod);
+    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId, testSetup.org.avatar.address, 2), EtherPeriod);
+    assert.equal(await testSetup.contributionReward.getRedeemedPeriods(proposalId, testSetup.org.avatar.address, 3), ExternalTokenPeriod);
 };
 
-const checkRedeemedPeriodsLeft = async function(
-                                            testSetup,
-                                            proposalId,
-                                            ReputationPeriod,
-                                            nativeTokenPeriod,
-                                            EtherPeriod,
-                                            ExternalTokenPeriod
-                                            ) {
-    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId,testSetup.org.avatar.address,0),ReputationPeriod);
-    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId,testSetup.org.avatar.address,1),nativeTokenPeriod);
-    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId,testSetup.org.avatar.address,2),EtherPeriod);
-    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId, testSetup.org.avatar.address,3),ExternalTokenPeriod);
+const checkRedeemedPeriodsLeft = async function (
+    testSetup,
+    proposalId,
+    ReputationPeriod,
+    nativeTokenPeriod,
+    EtherPeriod,
+    ExternalTokenPeriod
+) {
+    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId, testSetup.org.avatar.address, 0), ReputationPeriod);
+    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId, testSetup.org.avatar.address, 1), nativeTokenPeriod);
+    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId, testSetup.org.avatar.address, 2), EtherPeriod);
+    assert.equal(await testSetup.contributionReward.getPeriodsToPay(proposalId, testSetup.org.avatar.address, 3), ExternalTokenPeriod);
 };
 
-const setupContributionRewardParams = async function(
-                                            contributionReward,
-                                            orgNativeTokenFee=0,
-                                            ) {
-  var contributionRewardParams = new ContributionRewardParams();
-  contributionRewardParams.votingMachine = await helpers.setupAbsoluteVote();
-  contributionRewardParams.orgNativeTokenFee =  orgNativeTokenFee;
-  await contributionReward.setParameters(contributionRewardParams.orgNativeTokenFee,
-                                         contributionRewardParams.votingMachine.params,
-                                         contributionRewardParams.votingMachine.absoluteVote.address);
-  contributionRewardParams.paramsHash = await contributionReward.getParametersHash(contributionRewardParams.orgNativeTokenFee,
-                                                                                   contributionRewardParams.votingMachine.params,
-                                                                                   contributionRewardParams.votingMachine.absoluteVote.address);
-  return contributionRewardParams;
+const setupContributionRewardParams = async function (
+    contributionReward,
+    orgNativeTokenFee = 0,
+) {
+    var contributionRewardParams = new ContributionRewardParams();
+    contributionRewardParams.votingMachine = await helpers.setupAbsoluteVote();
+    contributionRewardParams.orgNativeTokenFee = orgNativeTokenFee;
+    await contributionReward.setParameters(contributionRewardParams.orgNativeTokenFee,
+        contributionRewardParams.votingMachine.params,
+        contributionRewardParams.votingMachine.absoluteVote.address);
+    contributionRewardParams.paramsHash = await contributionReward.getParametersHash(contributionRewardParams.orgNativeTokenFee,
+        contributionRewardParams.votingMachine.params,
+        contributionRewardParams.votingMachine.absoluteVote.address);
+    return contributionRewardParams;
 };
 
-const setup = async function (accounts,orgNativeTokenFee=0) {
-   var testSetup = new helpers.TestSetup();
-   testSetup.fee = 10;
-   testSetup.standardTokenMock = await StandardTokenMock.new(accounts[1],100);
-   testSetup.contributionReward = await ContributionReward.new();
-   var controllerCreator = await ControllerCreator.new();
-   testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.GENESIS_SCHEME_GAS_LIMIT});
-   testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.contributionRewardParams= await setupContributionRewardParams(testSetup.contributionReward,orgNativeTokenFee);
-   var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.contributionReward.address],[testSetup.contributionRewardParams.paramsHash],[permissions]);
-   return testSetup;
+const setup = async function (accounts, orgNativeTokenFee = 0) {
+    var testSetup = new helpers.TestSetup();
+    testSetup.fee = 10;
+    testSetup.standardTokenMock = await StandardTokenMock.new(accounts[1], 100);
+    testSetup.contributionReward = await ContributionReward.new();
+    var controllerCreator = await ControllerCreator.new();
+    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address, { gas: constants.GENESIS_SCHEME_GAS_LIMIT });
+    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator, accounts[0], 1000, 1000);
+    testSetup.contributionRewardParams = await setupContributionRewardParams(testSetup.contributionReward, orgNativeTokenFee);
+    var permissions = "0x00000000";
+    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address, [testSetup.contributionReward.address], [testSetup.contributionRewardParams.paramsHash], [permissions]);
+    return testSetup;
 };
-contract('ContributionReward', function(accounts) {
+contract('ContributionReward', function (accounts) {
 
-   it("setParameters", async function() {
-     var contributionReward = await ContributionReward.new();
-     var params = await setupContributionRewardParams(contributionReward);
-     var parameters = await contributionReward.parameters(params.paramsHash);
-     assert.equal(parameters[2],params.votingMachine.absoluteVote.address);
-     });
+    it("execute proposeContributionReward nultiple beneficiaries ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = 12;
+        var nativeTokenReward = 12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, 0, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [accounts[1], accounts[2], accounts[3]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, true, false, false]);
+        let tokens = await testSetup.org.token.balanceOf(accounts[1]);
+        assert.equal(tokens.toNumber(), nativeTokenReward);
+        tokens = await testSetup.org.token.balanceOf(accounts[2]);
+        assert.equal(tokens.toNumber(), nativeTokenReward);
+        tokens = await testSetup.org.token.balanceOf(accounts[3]);
+        assert.equal(tokens.toNumber(), nativeTokenReward);
+
+        const beneficiaries = await testSetup.contributionReward.getBeneficiaries(proposalId, testSetup.org.avatar.address);
+        assert.equal(beneficiaries.length, 3);
+        assert.equal(beneficiaries[0], accounts[1]);
+        assert.equal(beneficiaries[1], accounts[2]);
+        assert.equal(beneficiaries[2], accounts[3]);
+    });
+
+    it("setParameters", async function () {
+        var contributionReward = await ContributionReward.new();
+        var params = await setupContributionRewardParams(contributionReward);
+        var parameters = await contributionReward.parameters(params.paramsHash);
+        assert.equal(parameters[2], params.votingMachine.absoluteVote.address);
+    });
 
 
-    it("proposeContributionReward log", async function() {
-      var testSetup = await setup(accounts,0);
-      var periodLength = 1;
-      var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                     "description",
-                                                                     0,
-                                                                     [0,0,0,periodLength,0],
-                                                                     testSetup.standardTokenMock.address,
-                                                                     accounts[0]);
-      assert.equal(tx.logs.length, 1);
-      assert.equal(tx.logs[0].event, "NewContributionProposal");
-     });
+    it("proposeContributionReward log", async function () {
+        var testSetup = await setup(accounts, 0);
+        var periodLength = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "NewContributionProposal");
+    });
 
-     it("proposeContributionReward fees", async function() {
-       var testSetup = await setup(accounts,14);
-       var periodLength = 1;
+    it("proposeContributionReward fees", async function () {
+        var testSetup = await setup(accounts, 14);
+        var periodLength = 1;
 
-       var balanceBefore  = await testSetup.standardTokenMock.balanceOf(testSetup.org.avatar.address);
-       //give approval to scheme to do the fees transfer
-       await testSetup.org.token.approve(testSetup.contributionReward.address,100);
-       var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                      "description",
-                                                                      0,
-                                                                      [0,0,0,periodLength,0],
-                                                                      testSetup.standardTokenMock.address,
-                                                                      accounts[0],
-                                                                      {from:accounts[0]}
-                                                                    );
-       assert.equal(tx.logs.length, 1);
-       assert.equal(tx.logs[0].event, "NewContributionProposal");
-       var balance  = await testSetup.org.token.balanceOf(testSetup.org.avatar.address);
-       assert.equal(balance.toNumber(),testSetup.contributionRewardParams.orgNativeTokenFee);
-       balance  = await testSetup.standardTokenMock.balanceOf(testSetup.org.avatar.address);
-       assert.equal(balance.toNumber(),balanceBefore.toNumber());
-      });
+        var balanceBefore = await testSetup.standardTokenMock.balanceOf(testSetup.org.avatar.address);
+        //give approval to scheme to do the fees transfer
+        await testSetup.org.token.approve(testSetup.contributionReward.address, 100);
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            [accounts[0]],
+            { from: accounts[0] }
+        );
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "NewContributionProposal");
+        var balance = await testSetup.org.token.balanceOf(testSetup.org.avatar.address);
+        assert.equal(balance.toNumber(), testSetup.contributionRewardParams.orgNativeTokenFee);
+        balance = await testSetup.standardTokenMock.balanceOf(testSetup.org.avatar.address);
+        assert.equal(balance.toNumber(), balanceBefore.toNumber());
+    });
 
-      it("proposeContributionReward check owner vote", async function() {
+    it("proposeContributionReward check owner vote", async function () {
         var testSetup = await setup(accounts);
         var periodLength = 1;
         var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                       "description",
-                                                                       0,
-                                                                       [0,0,0,periodLength,0],
-                                                                       testSetup.standardTokenMock.address,
-                                                                       accounts[0]
-                                                                     );
-        var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-        await helpers.checkVoteInfo(testSetup.contributionRewardParams.votingMachine.absoluteVote,proposalId,accounts[0],[1,testSetup.contributionRewardParams.votingMachine.reputationArray[0]]);
-       });
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]
+        );
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await helpers.checkVoteInfo(testSetup.contributionRewardParams.votingMachine.absoluteVote, proposalId, accounts[0], [1, testSetup.contributionRewardParams.votingMachine.reputationArray[0]]);
+    });
 
-       it("proposeContributionReward check beneficiary==0", async function() {
-         var testSetup = await setup(accounts);
-         var beneficiary = 0;
-         var periodLength = 1;
-         var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                        "description",
-                                                                        0,
-                                                                        [0,0,0,periodLength,0],
-                                                                        testSetup.standardTokenMock.address,
-                                                                        beneficiary
-                                                                      );
-         assert.equal(await helpers.getValueFromLogs(tx, '_beneficiary'),accounts[0]);
-        });
+    it("proposeContributionReward check beneficiary==[]", async function () {
+        var testSetup = await setup(accounts);
+        var periodLength = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            []
+        );
+        const proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
 
-    it("execute proposeContributionReward  yes ", async function() {
-      var testSetup = await setup(accounts);
-      var periodLength = 1;
-      var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                     "description",
-                                                                     0,
-                                                                    [0,0,0,periodLength,0],
-                                                                     testSetup.standardTokenMock.address,
-                                                                     accounts[0]
-                                                                   );
-      //Vote with reputation to trigger execution
-      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-      await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-      var organizationsProposals = await testSetup.contributionReward.organizationsProposals(testSetup.org.avatar.address,proposalId);
-      assert.notEqual(organizationsProposals[9],0);//executionTime
-     });
+        const beneficiaries = await testSetup.contributionReward.getBeneficiaries(proposalId, testSetup.org.avatar.address);
+        assert(Array.isArray(beneficiaries), "_beneficiaries is not found or not an array");
+        assert.equal(beneficiaries[0], accounts[0], "_beneficiaries has not been properly intialized");
+    });
 
-      it("execute proposeContributionReward  mint reputation ", async function() {
+    it("execute proposeContributionReward  yes ", async function () {
+        var testSetup = await setup(accounts);
+        var periodLength = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        var organizationsProposals = await testSetup.contributionReward.organizationsProposals(testSetup.org.avatar.address, proposalId);
+        assert.notEqual(organizationsProposals[9], 0);//executionTime
+    });
+
+    it("execute proposeContributionReward  mint reputation ", async function () {
         var testSetup = await setup(accounts);
         var reputationReward = 12;
         var periodLength = 50;
         var numberOfPeriods = 1;
         var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                       "description",
-                                                                       reputationReward,
-                                                                       [0,0,0,periodLength,numberOfPeriods],
-                                                                       testSetup.standardTokenMock.address,
-                                                                       accounts[1]
-                                                                     );
+            "description",
+            reputationReward,
+            [0, 0, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [accounts[1]]
+        );
         //Vote with reputation to trigger execution
-        var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-        await helpers.increaseTime(periodLength+1);
-        tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[true,false,false,false]);
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [true, false, false, false]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "RedeemReputation");
+        assert.equal(tx.logs[0].args._amount, reputationReward, "reputation was not reported transferred");
+        var rep = await testSetup.org.reputation.reputationOf(accounts[1]);
+        assert.equal(rep.toNumber(), reputationReward, "reputation was not received by beneficiary");
+    });
+
+    it("execute proposeContributionReward  mint tokens ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = 12;
+        var nativeTokenReward = 12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, 0, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [accounts[1]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, true, false, false]);
+        var tokens = await testSetup.org.token.balanceOf(accounts[1]);
+        assert.equal(tokens.toNumber(), nativeTokenReward);
+    });
+
+    it("execute proposeContributionReward  send ethers ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = 12;
+        var nativeTokenReward = 12;
+        var ethReward = 12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        //send some ether to the org avatar
+        var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+        web3.eth.sendTransaction({ from: accounts[0], to: testSetup.org.avatar.address, value: 20 });
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, ethReward, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [otherAvatar.address]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        var eth = web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward);
+    });
+
+    it("execute proposeContributionReward  send externalToken ", async function () {
+        var testSetup = await setup(accounts);
+        //give some tokens to organization avatar
+        await testSetup.standardTokenMock.transfer(testSetup.org.avatar.address, 30, { from: accounts[1] });
+        var reputationReward = 12;
+        var nativeTokenReward = 12;
+        var ethReward = 12;
+        var externalTokenReward = 12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        //send some ether to the org avatar
+        var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+        web3.eth.sendTransaction({ from: accounts[0], to: testSetup.org.avatar.address, value: 20 });
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, ethReward, externalTokenReward, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [otherAvatar.address]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, false, true]);
+        var tokens = await testSetup.standardTokenMock.balanceOf(otherAvatar.address);
+        assert.equal(tokens.toNumber(), externalTokenReward);
+    });
+
+    it("execute proposeContributionReward proposal decision=='no' send externalToken  ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = 12;
+        var nativeTokenReward = 12;
+        var ethReward = 12;
+        var externalTokenReward = 12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        //send some ether to the org avatar
+        var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+        web3.eth.sendTransaction({ from: accounts[0], to: testSetup.org.avatar.address, value: 20 });
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, ethReward, externalTokenReward, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [otherAvatar.address]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        var organizationsProposals = await testSetup.contributionReward.organizationsProposals(testSetup.org.avatar.address, proposalId);
+        var beneficiaries = await testSetup.contributionReward.getBeneficiaries(proposalId, testSetup.org.avatar.address);
+        assert.equal(beneficiaries[0], otherAvatar.address);//beneficiary
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 0, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        try {
+            await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [true, true, true, true]);
+            assert(false, 'redeem should revert because there was no positive voting');
+        } catch (ex) {
+            helpers.assertVMException(ex);
+        }
+    });
+
+
+    it("redeem periods ether ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = 0;
+        var nativeTokenReward = 0;
+        var ethReward = 3;
+        var periodLength = 50;
+        var numberOfPeriods = 5;
+        //send some ether to the org avatar
+        var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+        web3.eth.sendTransaction({ from: accounts[0], to: testSetup.org.avatar.address, value: 12 });
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [nativeTokenReward, ethReward, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [otherAvatar.address]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 0, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 1, 1, 1, 1);
+
+
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "RedeemEther");
+        assert.equal(tx.logs[0].args._amount, ethReward);
+        var eth = web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 1, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 1, 1, 0, 1);
+        //now try again on the same period
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        assert.equal(tx.logs.length, 0);
+        eth = web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward);
+
+        //now try again on 2nd period
+        await helpers.increaseTime(periodLength + 1);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 1, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 2, 2, 1, 2);
+
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "RedeemEther");
+        assert.equal(tx.logs[0].args._amount, ethReward);
+        eth = await web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward * 2);
+
+        //now try again on 4th period
+        await helpers.increaseTime((periodLength * 2) + 1);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 2, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 4, 4, 2, 4);
+
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "RedeemEther");
+        assert.equal(tx.logs[0].args._amount, ethReward * 2);
+        eth = await web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward * 4);
+
+        //now try again on 5th period - no ether on avatar should revert
+        await helpers.increaseTime(periodLength + 1);
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 4, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 5, 5, 1, 5);
+        try {
+            await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+            assert(false, 'redeem should revert because no ether left on avatar');
+        } catch (ex) {
+            helpers.assertVMException(ex);
+        }
+        web3.eth.sendTransaction({ from: accounts[0], to: testSetup.org.avatar.address, value: ethReward });
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 4, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 5, 5, 1, 5);
+
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "RedeemEther");
+        assert.equal(tx.logs[0].args._amount, ethReward);
+        eth = await web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward * 5);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 5, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 5, 5, 0, 5);
+
+
+        //cannot redeem any more..
+        await helpers.increaseTime(periodLength + 1);
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [false, false, true, false]);
+        assert.equal(tx.logs.length, 0);
+        eth = await web3.eth.getBalance(otherAvatar.address);
+        assert.equal(eth.toNumber(), ethReward * 5);
+
+        await checkRedeemedPeriods(testSetup, proposalId, 0, 0, 5, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 5, 5, 0, 5);
+    });
+
+    it("execute proposeContributionReward  mint negative reputation ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = -12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [0, 0, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 1, { from: accounts[2] });
+        await helpers.increaseTime(periodLength + 1);
+        tx = await testSetup.contributionReward.redeem(proposalId, testSetup.org.avatar.address, [true, false, false, false]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "RedeemReputation");
         assert.equal(tx.logs[0].args._amount, reputationReward);
-        var rep = await testSetup.org.reputation.reputationOf(accounts[1]);
-        assert.equal(rep.toNumber(),reputationReward);
-       });
-
-       it("execute proposeContributionReward  mint tokens ", async function() {
-         var testSetup = await setup(accounts);
-         var reputationReward = 12;
-         var nativeTokenReward = 12;
-         var periodLength = 50;
-         var numberOfPeriods = 1;
-         var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                        "description",
-                                                                        reputationReward,
-                                                                        [nativeTokenReward,0,0,periodLength,numberOfPeriods],
-                                                                        testSetup.standardTokenMock.address,
-                                                                        accounts[1]
-                                                                      );
-         //Vote with reputation to trigger execution
-         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-         await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-         await helpers.increaseTime(periodLength+1);
-         tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,true,false,false]);
-         var tokens = await testSetup.org.token.balanceOf(accounts[1]);
-         assert.equal(tokens.toNumber(),nativeTokenReward);
-        });
-
-        it("execute proposeContributionReward  send ethers ", async function() {
-          var testSetup = await setup(accounts);
-          var reputationReward = 12;
-          var nativeTokenReward = 12;
-          var ethReward = 12;
-          var periodLength = 50;
-          var numberOfPeriods = 1;
-          //send some ether to the org avatar
-          var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-          web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:20});
-          var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                         "description",
-                                                                         reputationReward,
-                                                                         [nativeTokenReward,ethReward,0,periodLength,numberOfPeriods],
-                                                                         testSetup.standardTokenMock.address,
-                                                                         otherAvatar.address
-                                                                       );
-          //Vote with reputation to trigger execution
-          var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-          await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-          await helpers.increaseTime(periodLength+1);
-          await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-          var eth = web3.eth.getBalance(otherAvatar.address);
-          assert.equal(eth.toNumber(),ethReward);
-         });
-
-         it("execute proposeContributionReward  send externalToken ", async function() {
-           var testSetup = await setup(accounts);
-           //give some tokens to organization avatar
-           await testSetup.standardTokenMock.transfer(testSetup.org.avatar.address,30,{from:accounts[1]});
-           var reputationReward = 12;
-           var nativeTokenReward = 12;
-           var ethReward = 12;
-           var externalTokenReward = 12;
-           var periodLength = 50;
-           var numberOfPeriods = 1;
-           //send some ether to the org avatar
-           var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-           web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:20});
-           var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                          "description",
-                                                                          reputationReward,
-                                                                          [nativeTokenReward,ethReward,externalTokenReward,periodLength,numberOfPeriods],
-                                                                          testSetup.standardTokenMock.address,
-                                                                          otherAvatar.address
-                                                                        );
-           //Vote with reputation to trigger execution
-           var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-           await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-           await helpers.increaseTime(periodLength+1);
-           await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,false,true]);
-           var tokens = await testSetup.standardTokenMock.balanceOf(otherAvatar.address);
-           assert.equal(tokens.toNumber(),externalTokenReward);
-          });
-
-          it("execute proposeContributionReward proposal decision=='no' send externalToken  ", async function() {
-            var testSetup = await setup(accounts);
-            var reputationReward = 12;
-            var nativeTokenReward = 12;
-            var ethReward = 12;
-            var externalTokenReward = 12;
-            var periodLength = 50;
-            var numberOfPeriods = 1;
-            //send some ether to the org avatar
-            var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-            web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:20});
-            var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                           "description",
-                                                                           reputationReward,
-                                                                           [nativeTokenReward,ethReward,externalTokenReward,periodLength,numberOfPeriods],
-                                                                           testSetup.standardTokenMock.address,
-                                                                           otherAvatar.address
-                                                                         );
-            //Vote with reputation to trigger execution
-            var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-            var organizationsProposals = await testSetup.contributionReward.organizationsProposals(testSetup.org.avatar.address,proposalId);
-            assert.equal(organizationsProposals[6],otherAvatar.address);//beneficiary
-            await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,0,{from:accounts[2]});
-            await helpers.increaseTime(periodLength+1);
-            try {
-              await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[true,true,true,true]);
-              assert(false, 'redeem should revert because there was no positive voting');
-            } catch (ex) {
-              helpers.assertVMException(ex);
-            }
-           });
+        var rep = await testSetup.org.reputation.reputationOf(accounts[0]);
+        assert.equal(rep.toNumber(), 1000 + reputationReward);
+    });
 
 
-           it("redeem periods ether ", async function() {
-             var testSetup = await setup(accounts);
-             var reputationReward = 0;
-             var nativeTokenReward = 0;
-             var ethReward = 3;
-             var periodLength = 50;
-             var numberOfPeriods = 5;
-             //send some ether to the org avatar
-             var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-             web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:12});
-             var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                            "description",
-                                                                            reputationReward,
-                                                                            [nativeTokenReward,ethReward,0,periodLength,numberOfPeriods],
-                                                                            testSetup.standardTokenMock.address,
-                                                                            otherAvatar.address
-                                                                          );
-             //Vote with reputation to trigger execution
-             var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-             await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-             await helpers.increaseTime(periodLength+1);
+    it("call execute should revert ", async function () {
+        var testSetup = await setup(accounts);
+        var reputationReward = -12;
+        var periodLength = 50;
+        var numberOfPeriods = 1;
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            reputationReward,
+            [0, 0, 0, periodLength, numberOfPeriods],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
+        try {
+            await testSetup.contributionReward.execute(proposalId, testSetup.org.avatar.address, 1);
+            assert(false, 'only voting machine can call execute');
+        } catch (ex) {
+            helpers.assertVMException(ex);
+        }
 
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,0,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,1,1,1,1);
+    });
 
 
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
+    it("get redeemed periods left ", async function () {
+        var testSetup = await setup(accounts);
+        var periodLength = 1;
+        await checkRedeemedPeriodsLeft(testSetup, 0, 0, 0, 0, 0);
+        await checkRedeemedPeriods(testSetup, 0, 0, 0, 0, 0);
+        var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+            "description",
+            0,
+            [0, 0, 0, periodLength, 0],
+            testSetup.standardTokenMock.address,
+            [accounts[0]]
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
 
-             assert.equal(tx.logs.length, 1);
-             assert.equal(tx.logs[0].event, "RedeemEther");
-             assert.equal(tx.logs[0].args._amount, ethReward);
-             var eth = web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward);
+        await checkRedeemedPeriods(testSetup, 0, 0, 0, 0, 0);
+        await checkRedeemedPeriodsLeft(testSetup, proposalId, 0, 0, 0, 0);
 
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,1,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,1,1,0,1);
-             //now try again on the same period
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-             assert.equal(tx.logs.length, 0);
-             eth = web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward);
-
-             //now try again on 2nd period
-             await helpers.increaseTime(periodLength+1);
-
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,1,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,2,2,1,2);
-
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-             assert.equal(tx.logs.length, 1);
-             assert.equal(tx.logs[0].event, "RedeemEther");
-             assert.equal(tx.logs[0].args._amount, ethReward);
-             eth = await web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward*2);
-
-             //now try again on 4th period
-             await helpers.increaseTime((periodLength*2)+1);
-
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,2,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,4,4,2,4);
-
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-             assert.equal(tx.logs.length, 1);
-             assert.equal(tx.logs[0].event, "RedeemEther");
-             assert.equal(tx.logs[0].args._amount, ethReward*2);
-             eth = await web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward*4);
-
-             //now try again on 5th period - no ether on avatar should revert
-             await helpers.increaseTime(periodLength+1);
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,4,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,5,5,1,5);
-             try {
-                  await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-                  assert(false, 'redeem should revert because no ether left on avatar');
-                  } catch (ex) {
-                   helpers.assertVMException(ex);
-             }
-             web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:ethReward});
-
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,4,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,5,5,1,5);
-
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-             assert.equal(tx.logs.length, 1);
-             assert.equal(tx.logs[0].event, "RedeemEther");
-             assert.equal(tx.logs[0].args._amount, ethReward);
-             eth = await web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward*5);
-
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,5,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,5,5,0,5);
-
-
-             //cannot redeem any more..
-             await helpers.increaseTime(periodLength+1);
-             tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
-             assert.equal(tx.logs.length, 0);
-             eth = await web3.eth.getBalance(otherAvatar.address);
-             assert.equal(eth.toNumber(),ethReward*5);
-
-             await checkRedeemedPeriods(testSetup,proposalId,0,0,5,0);
-             await checkRedeemedPeriodsLeft(testSetup,proposalId,5,5,0,5);
-            });
-
-                it("execute proposeContributionReward  mint negative reputation ", async function() {
-                  var testSetup = await setup(accounts);
-                  var reputationReward = -12;
-                  var periodLength = 50;
-                  var numberOfPeriods = 1;
-                  var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                                 "description",
-                                                                                 reputationReward,
-                                                                                 [0,0,0,periodLength,numberOfPeriods],
-                                                                                 testSetup.standardTokenMock.address,
-                                                                                 accounts[0]
-                                                                               );
-                  //Vote with reputation to trigger execution
-                  var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-                  await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
-                  await helpers.increaseTime(periodLength+1);
-                  tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[true,false,false,false]);
-                  assert.equal(tx.logs.length, 1);
-                  assert.equal(tx.logs[0].event, "RedeemReputation");
-                  assert.equal(tx.logs[0].args._amount, reputationReward);
-                  var rep = await testSetup.org.reputation.reputationOf(accounts[0]);
-                  assert.equal(rep.toNumber(),1000+reputationReward);
-                 });
-
-
-                 it("call execute should revert ", async function() {
-                   var testSetup = await setup(accounts);
-                   var reputationReward = -12;
-                   var periodLength = 50;
-                   var numberOfPeriods = 1;
-                   var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                                  "description",
-                                                                                  reputationReward,
-                                                                                  [0,0,0,periodLength,numberOfPeriods],
-                                                                                  testSetup.standardTokenMock.address,
-                                                                                  accounts[0]
-                                                                                );
-                   //Vote with reputation to trigger execution
-                   var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-                   try {
-                        await testSetup.contributionReward.execute(proposalId,testSetup.org.avatar.address,1);
-                        assert(false, 'only voting machine can call execute');
-                        } catch (ex) {
-                         helpers.assertVMException(ex);
-                   }
-
-                  });
-
-
-                  it("get redeemed periods left ", async function() {
-                    var testSetup = await setup(accounts);
-                    var periodLength = 1;
-                    await checkRedeemedPeriodsLeft(testSetup,0,0,0,0,0);
-                    await checkRedeemedPeriods(testSetup,0,0,0,0,0);
-                    var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
-                                                                                   "description",
-                                                                                   0,
-                                                                                  [0,0,0,periodLength,0],
-                                                                                   testSetup.standardTokenMock.address,
-                                                                                   accounts[0]
-                                                                                 );
-                    //Vote with reputation to trigger execution
-                    var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-
-                    await checkRedeemedPeriods(testSetup,0,0,0,0,0);
-                    await checkRedeemedPeriodsLeft(testSetup,proposalId,0,0,0,0);
-
-                   });
+    });
 
 
 });

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -316,7 +316,6 @@ contract('ContributionReward', function (accounts) {
         );
         //Vote with reputation to trigger execution
         var proposalId = helpers.getValueFromLogs(tx, '_proposalId', 1);
-        var organizationsProposals = await testSetup.contributionReward.organizationsProposals(testSetup.org.avatar.address, proposalId);
         var beneficiaries = await testSetup.contributionReward.getBeneficiaries(proposalId, testSetup.org.avatar.address);
         assert.equal(beneficiaries[0], otherAvatar.address);//beneficiary
         await testSetup.contributionRewardParams.votingMachine.absoluteVote.vote(proposalId, 0, { from: accounts[2] });


### PR DESCRIPTION
Resolves: #440 

- modifies ContributionReward to work with an array of beneficiaries
- adds new `getBeneficiaries` function
- fixes package scripts to work on Windows