### PR TITLE
proposalId in NewVestedAgreement and indexed proposalId

### DIFF
--- a/contracts/universalSchemes/VestingScheme.sol
+++ b/contracts/universalSchemes/VestingScheme.sol
@@ -239,7 +239,6 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
             agreements[agreementsCounter] = proposedAgreement;
             agreementsCounter++;
         // Log the new agreement:
-            emit NewVestedAgreement(agreementsCounter-1);
             emit ProposedVestedAgreement(agreementsCounter-1, _proposalId);
         }
         emit ProposalExecuted(_avatar,_proposalId,_param);

--- a/contracts/universalSchemes/VestingScheme.sol
+++ b/contracts/universalSchemes/VestingScheme.sol
@@ -15,8 +15,8 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
     event ProposalExecuted(address indexed _avatar, bytes32 indexed _proposalId,int _param);
     event ProposalDeleted(address indexed _avatar, bytes32 indexed _proposalId);
     event AgreementProposal(address indexed _avatar, bytes32 indexed _proposalId);
-    // _proposalId will only be set when agreement is created by proposal
-    event NewVestedAgreement(uint indexed _agreementId, bytes32 indexed _proposalId);
+    event NewVestedAgreement(uint indexed _agreementId);
+    event ProposedVestedAgreement(uint indexed _agreementId, bytes32 indexed _proposalId);
     event SignToCancelAgreement(uint indexed _agreementId, address indexed _signer);
     event RevokeSignToCancelAgreement(uint indexed _agreementId, address indexed _signer);
     event AgreementCancel(uint indexed _agreementId);
@@ -180,7 +180,7 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
         agreementsCounter++;
 
         // Log new agreement and return id:
-        emit NewVestedAgreement(agreementsCounter-1, "");
+        emit NewVestedAgreement(agreementsCounter-1);
         return(agreementsCounter-1);
     }
 
@@ -239,7 +239,8 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
             agreements[agreementsCounter] = proposedAgreement;
             agreementsCounter++;
         // Log the new agreement:
-            emit NewVestedAgreement(agreementsCounter-1, _proposalId);
+            emit NewVestedAgreement(agreementsCounter-1);
+            emit ProposedVestedAgreement(agreementsCounter-1, _proposalId);
         }
         emit ProposalExecuted(_avatar,_proposalId,_param);
         return true;

--- a/contracts/universalSchemes/VestingScheme.sol
+++ b/contracts/universalSchemes/VestingScheme.sol
@@ -14,8 +14,9 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
 
     event ProposalExecuted(address indexed _avatar, bytes32 indexed _proposalId,int _param);
     event ProposalDeleted(address indexed _avatar, bytes32 indexed _proposalId);
-    event AgreementProposal(address indexed _avatar, bytes32 _proposalId);
-    event NewVestedAgreement(uint indexed _agreementId);
+    event AgreementProposal(address indexed _avatar, bytes32 indexed _proposalId);
+    // _proposalId will only be set when agreement is created by proposal
+    event NewVestedAgreement(uint indexed _agreementId, bytes32 indexed _proposalId);
     event SignToCancelAgreement(uint indexed _agreementId, address indexed _signer);
     event RevokeSignToCancelAgreement(uint indexed _agreementId, address indexed _signer);
     event AgreementCancel(uint indexed _agreementId);
@@ -179,7 +180,7 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
         agreementsCounter++;
 
         // Log new agreement and return id:
-        emit NewVestedAgreement(agreementsCounter-1);
+        emit NewVestedAgreement(agreementsCounter-1, "");
         return(agreementsCounter-1);
     }
 
@@ -238,7 +239,7 @@ contract VestingScheme is UniversalScheme, ExecutableInterface {
             agreements[agreementsCounter] = proposedAgreement;
             agreementsCounter++;
         // Log the new agreement:
-            emit NewVestedAgreement(agreementsCounter-1);
+            emit NewVestedAgreement(agreementsCounter-1, _proposalId);
         }
         emit ProposalExecuted(_avatar,_proposalId,_param);
         return true;

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -115,7 +115,7 @@ contract('VestingScheme', function(accounts) {
           }
          });
 
-           it("execute proposeVestingAgreement- NewVestedAgreement supplies proposalId ", async function() {
+           it("execute proposeVestingAgreement- ProposedVestedAgreement supplies proposalId ", async function() {
              var testSetup = await setup(accounts);
 
 
@@ -133,7 +133,7 @@ contract('VestingScheme', function(accounts) {
              var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
              await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
             const found = await new Promise((resolve) => {
-                testSetup.vestingScheme.NewVestedAgreement({_proposalId: proposalId}, {fromBlock: 0})
+                testSetup.vestingScheme.ProposedVestedAgreement({_proposalId: proposalId}, {fromBlock: 0})
                     .get((err,events) => {
                         if (events.length === 1) {
                             resolve(events[0].args._proposalId === proposalId);
@@ -142,7 +142,7 @@ contract('VestingScheme', function(accounts) {
                         }
                     });
                 });
-                assert(found, "NewVestedAgreement did not supply the proposalId");
+                assert(found, "ProposedVestedAgreement did not supply the proposalId");
             });
 
            it("execute proposeVestingAgreement controller -yes - proposal data delete", async function() {
@@ -249,7 +249,7 @@ contract('VestingScheme', function(accounts) {
                assert.equal(await testSetup.org.token.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
               });
 
-              it("createVestedAgreement check agreement and proposal ids", async function() {
+              it("createVestedAgreement check agreement", async function() {
                 var testSetup = await setup(accounts);
                 var amountPerPeriod =3;
                 var numberOfAgreedPeriods = 7;
@@ -269,8 +269,6 @@ contract('VestingScheme', function(accounts) {
                 assert.equal(tx.logs[0].event, "NewVestedAgreement");
                 var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
                 assert.equal(agreementId,0);
-                var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-                assert.equal(proposalId,helpers.NULL_HASH);
                 tx = await testSetup.vestingScheme.createVestedAgreement( testSetup.standardTokenMock.address,
                                                                           accounts[0],
                                                                                accounts[1],
@@ -286,8 +284,6 @@ contract('VestingScheme', function(accounts) {
                 assert.equal(tx.logs[0].event, "NewVestedAgreement");
                 agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
                 assert.equal(agreementId,1);
-                proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-                assert.equal(proposalId,helpers.NULL_HASH);
                });
 
               it("createVestedAgreement check periodLength==0 ", async function() {

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -70,7 +70,7 @@ contract('VestingScheme', function(accounts) {
        assert.equal(tx.logs[0].event, "AgreementProposal");
        var avatarAddress = await helpers.getValueFromLogs(tx, '_avatar',1);
        assert.equal(avatarAddress,testSetup.org.avatar.address);
- });
+      });
 
        it("proposeVestingAgreement check owner vote", async function() {
          var testSetup = await setup(accounts);
@@ -133,7 +133,7 @@ contract('VestingScheme', function(accounts) {
              var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
              await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
             const found = await new Promise((resolve) => {
-                testSetup.vestingScheme.ProposedVestedAgreement({_proposalId: proposalId}, {fromBlock: 0})
+                testSetup.vestingScheme.ProposedVestedAgreement({_proposalId: proposalId}, {fromBlock: tx.blockNumber})
                     .get((err,events) => {
                         if (events.length === 1) {
                             resolve(events[0].args._proposalId === proposalId);
@@ -249,7 +249,7 @@ contract('VestingScheme', function(accounts) {
                assert.equal(await testSetup.org.token.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
               });
 
-              it("createVestedAgreement check agreement", async function() {
+              it("createVestedAgreement check agreement id ", async function() {
                 var testSetup = await setup(accounts);
                 var amountPerPeriod =3;
                 var numberOfAgreedPeriods = 7;

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -70,7 +70,7 @@ contract('VestingScheme', function(accounts) {
        assert.equal(tx.logs[0].event, "AgreementProposal");
        var avatarAddress = await helpers.getValueFromLogs(tx, '_avatar',1);
        assert.equal(avatarAddress,testSetup.org.avatar.address);
-      });
+ });
 
        it("proposeVestingAgreement check owner vote", async function() {
          var testSetup = await setup(accounts);
@@ -114,6 +114,36 @@ contract('VestingScheme', function(accounts) {
            helpers.assertVMException(ex);
           }
          });
+
+           it("execute proposeVestingAgreement- NewVestedAgreement supplies proposalId ", async function() {
+             var testSetup = await setup(accounts);
+
+
+             var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                            accounts[1],
+                                                                            web3.eth.blockNumber,
+                                                                            15,
+                                                                            2,
+                                                                            3,
+                                                                            11,
+                                                                            0,
+                                                                            [],
+                                                                            testSetup.org.avatar.address);
+            //Vote with reputation to trigger execution
+             var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+             await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,{from:accounts[2]});
+            const found = await new Promise((resolve) => {
+                testSetup.vestingScheme.NewVestedAgreement({_proposalId: proposalId}, {fromBlock: 0})
+                    .get((err,events) => {
+                        if (events.length === 1) {
+                            resolve(events[0].args._proposalId === proposalId);
+                        } else {
+                            resolve(false);
+                        }
+                    });
+                });
+                assert(found, "NewVestedAgreement did not supply the proposalId");
+            });
 
            it("execute proposeVestingAgreement controller -yes - proposal data delete", async function() {
              var testSetup = await setup(accounts);
@@ -219,7 +249,7 @@ contract('VestingScheme', function(accounts) {
                assert.equal(await testSetup.org.token.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
               });
 
-              it("createVestedAgreement check agreement id ", async function() {
+              it("createVestedAgreement check agreement and proposal ids", async function() {
                 var testSetup = await setup(accounts);
                 var amountPerPeriod =3;
                 var numberOfAgreedPeriods = 7;
@@ -239,6 +269,8 @@ contract('VestingScheme', function(accounts) {
                 assert.equal(tx.logs[0].event, "NewVestedAgreement");
                 var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
                 assert.equal(agreementId,0);
+                var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+                assert.equal(proposalId,helpers.NULL_HASH);
                 tx = await testSetup.vestingScheme.createVestedAgreement( testSetup.standardTokenMock.address,
                                                                           accounts[0],
                                                                                accounts[1],
@@ -254,6 +286,8 @@ contract('VestingScheme', function(accounts) {
                 assert.equal(tx.logs[0].event, "NewVestedAgreement");
                 agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
                 assert.equal(agreementId,1);
+                proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+                assert.equal(proposalId,helpers.NULL_HASH);
                });
 
               it("createVestedAgreement check periodLength==0 ", async function() {


### PR DESCRIPTION
Resolves: #448 
Resolves: #451

- For 451, rather than mess up the standardized parameters of ProposalExecuted I decided to add a new ProposedVestedAgreement event that contains _proposalId.  This will work for Arc.js.
- indexed _proposalId in AgreementProposal
