### PR TITLE
GP : Threshold exclude expired boosted proposals

### DIFF
--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -101,7 +101,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
     mapping(address=>uint) public orgBoostedProposalsCnt;
     StandardToken public stakingToken;
     mapping(address=>uint[]) public proposalsExpiredTimes; //proposals expired times
-    mapping(address=>uint) public quiteWindowProposals;
+    mapping(address=>uint) public quietWindowProposals;
     /**
      * @dev Constructor
      */
@@ -553,7 +553,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
           // solium-disable-next-line security/no-block-members
             expieredProposals = binarySearch(proposalsExpiredTimes[_avatar],0,proposalsExpiredTimes[_avatar].length-1,now);
         }
-        uint boostedProposals = orgBoostedProposalsCnt[_avatar].sub(expieredProposals).sub(quiteWindowProposals[_avatar]);
+        uint boostedProposals = orgBoostedProposalsCnt[_avatar].sub(expieredProposals).sub(quietWindowProposals[_avatar]);
         int216 e = 2;
 
         Parameters memory params = parameters[proposals[_proposalId].paramsHash];
@@ -856,7 +856,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
                 //quietEndingPeriod
                 proposal.boostedPhaseTime = _now;
                 if (proposal.state != ProposalState.QuietEndingPeriod) {
-                    quiteWindowProposals[proposal.avatar]++;
+                    quietWindowProposals[proposal.avatar]++;
                     proposalsExpiredTimes[proposal.avatar].push(_now + proposal.currentBoostedVotePeriodLimit);
                     proposal.currentBoostedVotePeriodLimit = params.quietEndingPeriod;
                     proposal.state = ProposalState.QuietEndingPeriod;

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1240,10 +1240,18 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
       await testSetup.genesisProtocol.vote(proposalId,1);
       await stake(testSetup,proposalId,1,100,accounts[0]);
+
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
       assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
-      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
+      var currentTime = await  web3.eth.getBlock("latest").timestamp;
+      var numberOfExpiredProposals = 0;
+      if (currentTime > await testSetup.genesisProtocol.proposalsExpiredTimes(testSetup.org.avatar.address,0)) {
+          numberOfExpiredProposals++;
+      }
+
+      var  threshold = Math.pow(2,((1-numberOfExpiredProposals)/1));
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),threshold);
       //set up another proposal
       tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
       proposalId = await getValueFromLogs(tx, '_proposalId');
@@ -1251,16 +1259,37 @@ contract('GenesisProtocol', function (accounts) {
       await testSetup.genesisProtocol.vote(proposalId,1);
       await stake(testSetup,proposalId,1,100,accounts[0]);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),2);
-      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
+       var numberOfBoostedProposals = await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address);
+      assert.equal(numberOfBoostedProposals,2);
+       currentTime = await  web3.eth.getBlock("latest").timestamp;
+       numberOfExpiredProposals = 0;
+      if (currentTime > await testSetup.genesisProtocol.proposalsExpiredTimes(testSetup.org.avatar.address,0)) {
+        numberOfExpiredProposals++;
+      }
+      if (currentTime > await testSetup.genesisProtocol.proposalsExpiredTimes(testSetup.org.avatar.address,1)) {
+        numberOfExpiredProposals++;
+      }
+
+        threshold = Math.pow(2,((numberOfBoostedProposals-numberOfExpiredProposals)/1));
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),threshold);
 
       //execute
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),2);
-      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),0);
+      numberOfBoostedProposals = await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address);
+      assert.equal(numberOfBoostedProposals,2);
+      currentTime = await  web3.eth.getBlock("latest").timestamp;
+      numberOfExpiredProposals = 0;
 
+      if (currentTime > await testSetup.genesisProtocol.proposalsExpiredTimes(testSetup.org.avatar.address,0)) {
+        numberOfExpiredProposals++;
+      }
+      if (currentTime > await testSetup.genesisProtocol.proposalsExpiredTimes(testSetup.org.avatar.address,1)) {
+        numberOfExpiredProposals++;
+      }
+      threshold = Math.pow(2,((numberOfBoostedProposals-numberOfExpiredProposals)/1));
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),threshold);
+      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),0);
     });
 
     it("reputation flow ", async () => {

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1289,7 +1289,7 @@ contract('GenesisProtocol', function (accounts) {
       }
       threshold = Math.pow(2,((numberOfBoostedProposals-numberOfExpiredProposals)/1));
       assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),threshold);
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),0);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),0);
     });
 
     it("reputation flow ", async () => {
@@ -1385,23 +1385,23 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(proposalInfo[8],4);//boosted
 
       await helpers.increaseTime(50); //get into the quite period
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),0);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),0);
 
       await testSetup.genesisProtocol.vote(proposalId,2,{from:accounts[0]}); //change winning vote
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),1);
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[8],5);//quietEndingPeriod -still not execute
       await helpers.increaseTime(15); //increase time
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),1);
 
       await testSetup.genesisProtocol.execute(proposalId);
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),1);
 
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[8],5);//boosted -still not execute
       await helpers.increaseTime(10); //increase time
       await testSetup.genesisProtocol.execute(proposalId);
-      assert.equal(await testSetup.genesisProtocol.quiteWindowProposals(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.quietWindowProposals(testSetup.org.avatar.address),1);
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[8],2);//boosted -still not execute
     });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -161,7 +161,7 @@ export const setupGenesisProtocol = async function (accounts,token,
   _daoBountyLimt=10
   ) {
   var votingMachine = new VotingMachine();
-  votingMachine.genesisProtocol = await GenesisProtocol.new(token);
+  votingMachine.genesisProtocol = await GenesisProtocol.new(token,{gas: constants.GENESIS_SCHEME_GAS_LIMIT});
 
   // set up a reputation system
   votingMachine.reputationArray = [20, 10 ,70];


### PR DESCRIPTION
Currently expired boosted proposals are included in the score threshold calculation as it is not auto  executed on expiration.
In order to execute these proposals client need to actively do vote, stake or execute calls for these proposals.
This PR aim to solve it.
As it is not secure ,efficient and gas consuming to iterate over all boosted proposals ,the contract will  maintain a sorted array of expiration proposals times (which is relative cheap to maintain as elements are added only at the end of the array (O(1)). 
Calculating the expired proposals number can be done in O(LogN) where N is the number of boosted proposals.   
The number of  boosted proposals for the threshold calculation is done by subtracting the the expired proposals from the total boosted number of proposals. 
