### PR TITLE
Threshold exclude expired boosted proposals

### DIFF
--- a/contracts/libs/OrderStatisticTree.sol
+++ b/contracts/libs/OrderStatisticTree.sol
@@ -24,7 +24,7 @@ library OrderStatisticTree {
      *      i.e. its index in the sorted list of elements of the tree
      * @param _tree the tree
      * @param _value the input value to find its rank.
-     * @return smaller - the number of elements in the tree which its number is
+     * @return smaller - the number of elements in the tree which their value is
      * less than the input value.
      */
     function rank(Tree storage _tree,uint _value) internal view returns (uint smaller) {

--- a/contracts/libs/OrderStatisticTree.sol
+++ b/contracts/libs/OrderStatisticTree.sol
@@ -1,0 +1,304 @@
+pragma solidity ^0.4.24;
+
+
+library OrderStatisticTree {
+
+    struct Node {
+        mapping (bool => uint) children; // a mapping of left(false) child and right(true) child nodes
+        uint parent; // parent node
+        bool side;   // side of the node on the tree (left or right)
+        uint height; //Height of this node
+        uint count; //Number of tree nodes below this node (including this one)
+        uint dupes; //Number of duplicates values for this node
+    }
+
+    struct Tree {
+        // a mapping between node value(uint) to Node
+        // the tree's root is always at node 0 ,which points to the "real" tree
+        // as its right child.this is done to eliminate the need to update the tree
+        // root in the case of rotation.(saving gas).
+        mapping(uint => Node) nodes;
+    }
+    /**
+     * @dev rank - find the rank of a value in the tree,
+     *      i.e. its index in the sorted list of elements of the tree
+     * @param _tree the tree
+     * @param _value the input value to find its rank.
+     * @return smaller - the number of elements in the tree which its number is
+     * less than the input value.
+     */
+    function rank(Tree storage _tree,uint _value) internal view returns (uint smaller) {
+        if (_value != 0) {
+            smaller = _tree.nodes[0].dupes;
+
+            uint cur = _tree.nodes[0].children[true];
+            Node storage currentNode = _tree.nodes[cur];
+
+            while (true) {
+                if (cur <= _value) {
+                    if (cur<_value) {
+                        smaller = smaller + 1+currentNode.dupes;
+                    }
+                    uint leftChild = currentNode.children[false];
+                    if (leftChild!=0) {
+                        smaller = smaller + _tree.nodes[leftChild].count;
+                    }
+                }
+                if (cur == _value) {
+                    break;
+                }
+                cur = currentNode.children[cur<_value];
+                if (cur == 0) {
+                    break;
+                }
+                currentNode = _tree.nodes[cur];
+            }
+        }
+    }
+
+    function count(Tree storage _tree) internal view returns (uint) {
+        Node storage root = _tree.nodes[0];
+        Node memory child = _tree.nodes[root.children[true]];
+        return root.dupes+child.count;
+    }
+
+    function updateCount(Tree storage _tree,uint _value) private {
+        Node storage n = _tree.nodes[_value];
+        n.count = 1+_tree.nodes[n.children[false]].count+_tree.nodes[n.children[true]].count+n.dupes;
+    }
+
+    function updateCounts(Tree storage _tree,uint _value) private {
+        uint parent = _tree.nodes[_value].parent;
+        while (parent!=0) {
+            updateCount(_tree,parent);
+            parent = _tree.nodes[parent].parent;
+        }
+    }
+
+    function updateHeight(Tree storage _tree,uint _value) private {
+        Node storage n = _tree.nodes[_value];
+        uint heightLeft = _tree.nodes[n.children[false]].height;
+        uint heightRight = _tree.nodes[n.children[true]].height;
+        if (heightLeft > heightRight)
+            n.height = heightLeft+1;
+        else
+            n.height = heightRight+1;
+    }
+
+    function balanceFactor(Tree storage _tree,uint _value) view private returns (int bf) {
+        Node storage n = _tree.nodes[_value];
+        return int(_tree.nodes[n.children[false]].height)-int(_tree.nodes[n.children[true]].height);
+    }
+
+    function rotate(Tree storage _tree,uint _value,bool dir) private {
+        bool otherDir = !dir;
+        Node storage n = _tree.nodes[_value];
+        bool side = n.side;
+        uint parent = n.parent;
+        uint valueNew = n.children[otherDir];
+        Node storage nNew = _tree.nodes[valueNew];
+        uint orphan = nNew.children[dir];
+        Node storage p = _tree.nodes[parent];
+        Node storage o = _tree.nodes[orphan];
+        p.children[side] = valueNew;
+        nNew.side = side;
+        nNew.parent = parent;
+        nNew.children[dir] = _value;
+        n.parent = valueNew;
+        n.side = dir;
+        n.children[otherDir] = orphan;
+        o.parent = _value;
+        o.side = otherDir;
+        updateHeight(_tree,_value);
+        updateHeight(_tree,valueNew);
+        updateCount(_tree,_value);
+        updateCount(_tree,valueNew);
+    }
+
+    function rebalanceInsert(Tree storage _tree,uint _nValue) private {
+        updateHeight(_tree,_nValue);
+        Node storage n = _tree.nodes[_nValue];
+        uint pValue = n.parent;
+        if (pValue!=0) {
+            int pBf = balanceFactor(_tree,pValue);
+            bool side = n.side;
+            int sign;
+            if (side)
+                sign = -1;
+            else
+                sign = 1;
+            if (pBf == sign*2) {
+                if (balanceFactor(_tree,_nValue) == (-1 * sign)) {
+                    rotate(_tree,_nValue,side);
+                }
+                rotate(_tree,pValue,!side);
+            } else if (pBf != 0) {
+                rebalanceInsert(_tree,pValue);
+            }
+        }
+    }
+
+    function rebalanceDelete(Tree storage _tree,uint _pValue,bool side) private {
+        if (_pValue!=0) {
+            updateHeight(_tree,_pValue);
+            int pBf = balanceFactor(_tree,_pValue);
+            int sign;
+            if (side)
+                sign = 1;
+            else
+                sign = -1;
+            int bf = balanceFactor(_tree,_pValue);
+            if (bf==(2*sign)) {
+                Node storage p = _tree.nodes[_pValue];
+                uint sValue = p.children[!side];
+                int sBf = balanceFactor(_tree,sValue);
+                if (sBf == (-1 * sign)) {
+                    rotate(_tree,sValue,!side);
+                }
+                rotate(_tree,_pValue,side);
+                if (sBf!=0) {
+                    p = _tree.nodes[_pValue];
+                    rebalanceDelete(_tree,p.parent,p.side);
+                }
+            } else if (pBf != sign) {
+                p = _tree.nodes[_pValue];
+                rebalanceDelete(_tree,p.parent,p.side);
+            }
+        }
+    }
+
+    function fixParents(Tree storage _tree,uint parent,bool side) private {
+        if (parent!=0) {
+            updateCount(_tree,parent);
+            updateCounts(_tree,parent);
+            rebalanceDelete(_tree,parent,side);
+        }
+    }
+
+    function insertHelper(Tree storage _tree,uint _pValue,bool _side,uint _value) private {
+        Node storage root = _tree.nodes[_pValue];
+        uint cValue = root.children[_side];
+        if (cValue==0) {
+            root.children[_side] = _value;
+            Node storage child = _tree.nodes[_value];
+            child.parent = _pValue;
+            child.side = _side;
+            child.height = 1;
+            child.count = 1;
+            updateCounts(_tree,_value);
+            rebalanceInsert(_tree,_value);
+        } else if (cValue==_value) {
+            _tree.nodes[cValue].dupes++;
+            updateCount(_tree,_value);
+            updateCounts(_tree,_value);
+        } else {
+            insertHelper(_tree,cValue,(_value >= cValue),_value);
+        }
+    }
+
+    function insert(Tree storage _tree,uint _value) internal {
+        if (_value==0) {
+            _tree.nodes[_value].dupes++;
+        } else {
+            insertHelper(_tree,0,true,_value);
+        }
+    }
+
+    function rightmostLeaf(Tree storage _tree,uint _value) view private returns (uint leaf) {
+        uint child = _tree.nodes[_value].children[true];
+        if (child!=0) {
+            return rightmostLeaf(_tree,child);
+        } else {
+            return _value;
+        }
+    }
+
+    function zeroOut(Tree storage _tree,uint _value) private {
+        Node storage n = _tree.nodes[_value];
+        n.parent = 0;
+        n.side = false;
+        n.children[false] = 0;
+        n.children[true] = 0;
+        n.count = 0;
+        n.height = 0;
+        n.dupes = 0;
+    }
+
+    function removeBranch(Tree storage _tree,uint _value,uint _left) private {
+        uint ipn = rightmostLeaf(_tree,_left);
+        Node storage i = _tree.nodes[ipn];
+        uint dupes = i.dupes;
+        removeHelper(_tree,ipn);
+        Node storage n = _tree.nodes[_value];
+        uint parent = n.parent;
+        Node storage p = _tree.nodes[parent];
+        uint height = n.height;
+        bool side = n.side;
+        uint ncount = n.count;
+        uint right = n.children[true];
+        uint left = n.children[false];
+        p.children[side] = ipn;
+        i.parent = parent;
+        i.side = side;
+        i.count = ncount+dupes-n.dupes;
+        i.height = height;
+        i.dupes = dupes;
+        if (left!=0) {
+            i.children[false] = left;
+            _tree.nodes[left].parent = ipn;
+        }
+        if (right!=0) {
+            i.children[true] = right;
+            _tree.nodes[right].parent = ipn;
+        }
+        zeroOut(_tree,_value);
+        updateCounts(_tree,ipn);
+    }
+
+    function removeHelper(Tree storage _tree,uint _value) private {
+        Node storage n = _tree.nodes[_value];
+        uint parent = n.parent;
+        bool side = n.side;
+        Node storage p = _tree.nodes[parent];
+        uint left = n.children[false];
+        uint right = n.children[true];
+        if ((left == 0) && (right == 0)) {
+            p.children[side] = 0;
+            zeroOut(_tree,_value);
+            fixParents(_tree,parent,side);
+        } else if ((left != 0) && (right != 0)) {
+            removeBranch(_tree,_value,left);
+        } else {
+            uint child = left+right;
+            Node storage c = _tree.nodes[child];
+            p.children[side] = child;
+            c.parent = parent;
+            c.side = side;
+            zeroOut(_tree,_value);
+            fixParents(_tree,parent,side);
+        }
+    }
+
+    function remove(Tree storage _tree,uint _value) internal {
+        Node storage n = _tree.nodes[_value];
+        if (_value==0) {
+            if (n.dupes==0) {
+                return;
+            }
+        } else {
+            if (n.count==0) {
+                return;
+            }
+        }
+        if (n.dupes>0) {
+            n.dupes--;
+            if (_value!=0) {
+                n.count--;
+            }
+            fixParents(_tree,n.parent,n.side);
+        } else {
+            removeHelper(_tree,_value);
+        }
+    }
+
+}

--- a/contracts/test/OrderStatisticTreeMock.sol
+++ b/contracts/test/OrderStatisticTreeMock.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.24;
+
+import "../libs/OrderStatisticTree.sol";
+
+
+contract OrderStatisticTreeMock {
+    using OrderStatisticTree for OrderStatisticTree.Tree;
+
+    OrderStatisticTree.Tree tree;
+
+    function insert(uint value) public {
+        tree.insert(value);
+    }
+
+    function rank(uint value) public view returns (uint) {
+        return tree.rank(value);
+    }
+
+    function count() public view returns (uint) {
+        return tree.count();
+    }
+
+    function remove(uint _value) public {
+        return tree.remove(_value);
+    }
+}

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -86,7 +86,7 @@ const setup = async function (accounts,_preBoostedVoteRequiredPercentage=50,
                                       _daoBountyLimt =10 ) {
    var testSetup = new helpers.TestSetup();
    testSetup.stakingToken = await ERC827TokenMock.new(accounts[0],1000);
-   testSetup.genesisProtocol = await GenesisProtocol.new(testSetup.stakingToken.address);
+   testSetup.genesisProtocol = await GenesisProtocol.new(testSetup.stakingToken.address,{gas: constants.ARC_GAS_LIMIT});
 
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
@@ -1240,6 +1240,7 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
       await testSetup.genesisProtocol.vote(proposalId,1);
       await stake(testSetup,proposalId,1,100,accounts[0]);
+
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
       assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
@@ -1251,14 +1252,35 @@ contract('GenesisProtocol', function (accounts) {
       await testSetup.genesisProtocol.vote(proposalId,1);
       await stake(testSetup,proposalId,1,100,accounts[0]);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),2);
+      var numberOfBoostedProposals = await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address);
+      assert.equal(numberOfBoostedProposals,2);
+
       assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),4);
 
       //execute
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
-      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),1);
+    });
+
+    it("dynamic threshold without execute", async () => {
+      var testSetup = await setup(accounts);
+
+      let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
+      var proposalId = await getValueFromLogs(tx, '_proposalId');
+
+      await testSetup.genesisProtocol.vote(proposalId,1);
+      await stake(testSetup,proposalId,1,100,accounts[0]);
+
+      //set up another proposal
+      tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
+      proposalId = await getValueFromLogs(tx, '_proposalId');
+      //boost it
+      await testSetup.genesisProtocol.vote(proposalId,1);
+      await stake(testSetup,proposalId,1,100,accounts[0]);
+      //execute
+      await helpers.increaseTime(61);
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),1);
     });
 
     it("reputation flow ", async () => {
@@ -1354,17 +1376,32 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(proposalInfo[8],4);//boosted
 
       await helpers.increaseTime(50); //get into the quite period
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
+
       await testSetup.genesisProtocol.vote(proposalId,2,{from:accounts[0]}); //change winning vote
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),2);
+
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[8],5);//quietEndingPeriod -still not execute
       await helpers.increaseTime(15); //increase time
+
       await testSetup.genesisProtocol.execute(proposalId);
+
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[8],5);//boosted -still not execute
       await helpers.increaseTime(10); //increase time
+      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
+
       await testSetup.genesisProtocol.execute(proposalId);
+      await helpers.increaseTime(100); //increase time
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),1);
+
+      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
+
+      assert.equal(await testSetup.genesisProtocol.threshold(proposalId,testSetup.org.avatar.address),1);
+
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],2);//boosted -still not execute
+      assert.equal(proposalInfo[8],2);//executed
     });
 
     it("scoreThresholdParams and proposalAvatar", async () => {
@@ -1442,4 +1479,5 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
 
     });
+
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -161,7 +161,7 @@ export const setupGenesisProtocol = async function (accounts,token,
   _daoBountyLimt=10
   ) {
   var votingMachine = new VotingMachine();
-  votingMachine.genesisProtocol = await GenesisProtocol.new(token);
+  votingMachine.genesisProtocol = await GenesisProtocol.new(token,{gas: constants.ARC_GAS_LIMIT});
 
   // set up a reputation system
   votingMachine.reputationArray = [20, 10 ,70];

--- a/test/orderstatistictree.js
+++ b/test/orderstatistictree.js
@@ -1,0 +1,76 @@
+const OrderStatisticTreeMock = artifacts.require("./OrderStatisticTreeMock.sol");
+
+const getRandomInt = async function (max) {
+  return Math.floor(Math.random() * Math.floor(max));
+};
+
+
+contract('OrderStatisticTree', function () {
+
+  it("insert, rank and count ", async function () {
+    var values = [3,5,5,6,1,100,50];
+    var ranks  = [1,2,2,4,0,6,5];
+    var orderStatisticTree = await OrderStatisticTreeMock.new();
+    for (var i = 0;i<values.length;i++) {
+      await orderStatisticTree.insert(values[i]);
+    }
+    var count = await orderStatisticTree.count();
+
+    var rank;
+    assert.equal(count,values.length);
+    for (i = 0 ;i< count ;i++) {
+      rank = await orderStatisticTree.rank(values[i]);
+      assert.equal(ranks[i],rank);
+    }
+
+    var valuesInBetween = [4,8,20,101,2];
+    var ranksInBetween  = [2,5,5,7,1];
+
+    for (i = 0 ;i< valuesInBetween.length ;i++) {
+      rank = await orderStatisticTree.rank(valuesInBetween[i]);
+      assert.equal(ranksInBetween[i],rank);
+    }
+
+    for (i = values.length-1 ;i>=0 ;i--) {
+      await orderStatisticTree.remove(values[i]);
+      assert.equal(await orderStatisticTree.count(),i);
+    }
+
+  });
+
+  it("gas usage ", async function () {
+
+    var orderStatisticTree = await OrderStatisticTreeMock.new();
+    var tx,val;
+    var maxGasUsed = 0;
+    var values = {};
+    var elementNumber = 100;
+    for (var i = 0;i<elementNumber;i++) {
+      values[i] = await getRandomInt(500);
+      tx = await orderStatisticTree.insert(values[i]);
+      if (tx.receipt.gasUsed > maxGasUsed) {
+        maxGasUsed = tx.receipt.gasUsed;
+      }
+    }
+    assert.isBelow(maxGasUsed,380000);
+    maxGasUsed = 0;
+    for (i = 0;i<elementNumber;i++) {
+      val = await getRandomInt(500);
+      var txhash = await orderStatisticTree.rank.sendTransaction(val);
+      var receipt = await web3.eth.getTransactionReceipt(txhash);
+      if (receipt.gasUsed > maxGasUsed) {
+        maxGasUsed = receipt.gasUsed;
+      }
+    }
+    assert.isBelow(maxGasUsed,35000);
+    maxGasUsed = 0;
+    for (i = 0;i<elementNumber;i++) {
+      tx = await orderStatisticTree.remove(values[i]);
+      if (tx.receipt.gasUsed > maxGasUsed) {
+        maxGasUsed = tx.receipt.gasUsed;
+      }
+    }
+    assert.isBelow(maxGasUsed,500000);
+  });
+
+});


### PR DESCRIPTION
Currently expired boosted proposals are included in the score threshold calculation as it is not auto executed on expiration.
In order to execute these proposals client need to actively do vote, stake or execute calls for these proposals.
This PR aim to solve it .
As it is not secure ,efficient and gas consuming to iterate over all boosted proposals ,the contract will maintain an [Order Statistic Tree ](https://en.wikipedia.org/wiki/Order_statistic_tree) with a balanced [AVL tree](https://en.wikipedia.org/wiki/AVL_tree) of expiration proposals times.
 - Inserting an element (proposal expiration time) to the tree is O(LogN) complexity.
 - Getting the number of the expired proposals for a given specific time (Rank) is O(LogN) complexity.

N  = the number of booster proposals.

In term of gas cost , inserting an element to the tree is relative more expensive than getting a Rank as its need to update the contract storage .
On current implementation insert  operation to a tree with 1000 elements (1000 boosted proposal) will cost on average around 400000 gas .It will not increase dramaticly with more elements due to the algorithm complexity O(LogN).
Getting a Rank from a tree with 1000 elements cost around 40000 gas.
Insert is done on a boosting event (on staking) and also when a proposal is shifting to a "quite window" state.
Rank is done for each threshold calculation.
All can be further optimise by doing kind of maintenance work and removing "old" expired boosted proposals from the tree by executing this proposals.
Please note that there is a protocol incentive for clients to execute expired positive proposals.
 
Remove an element from the tree has the same cost of insertion.

The number of boosted proposals for the threshold calculation is done by subtracting the the expired proposals from the total boosted number of proposals.
