### PR TITLE
Redeemer helper contract 

### DIFF
--- a/contracts/universalSchemes/ContributionReward.sol
+++ b/contracts/universalSchemes/ContributionReward.sol
@@ -386,4 +386,16 @@ contract ContributionReward is UniversalScheme {
         return organizationsProposals[_avatar][_proposalId].redeemedPeriods[_redeemType];
     }
 
+    function getProposalEthReward(bytes32 _proposalId, address _avatar) public view returns (uint) {
+        return organizationsProposals[_avatar][_proposalId].ethReward;
+    }
+
+    function getProposalExternalTokenReward(bytes32 _proposalId, address _avatar) public view returns (uint) {
+        return organizationsProposals[_avatar][_proposalId].externalTokenReward;
+    }
+
+    function getProposalExternalToken(bytes32 _proposalId, address _avatar) public view returns (address) {
+        return organizationsProposals[_avatar][_proposalId].externalToken;
+    }
+
 }

--- a/contracts/utils/ARCUtils.sol
+++ b/contracts/utils/ARCUtils.sol
@@ -1,0 +1,107 @@
+pragma solidity ^0.4.24;
+
+import "../universalSchemes/ContributionReward.sol";
+import "../VotingMachines/GenesisProtocol.sol";
+
+
+contract ARCUtils {
+    using SafeMath for uint;
+
+    ContributionReward public contributionReward;
+    GenesisProtocol public genesisProtocol;
+
+    event ARCUtilsRedeem(bytes32 indexed _proposalId,
+                 bool _execute,
+                 bool _genesisProtocolRedeem,
+                 bool _genesisProtocolDaoBounty,
+                 bool _contributionRewardReputation,
+                 bool _contributionRewardNativeToken,
+                 bool _contributionRewardEther,
+                 bool _contributionRewardExternalToken
+    );
+
+    constructor(address _contributionReward,address _genesisProtocol) public {
+        contributionReward = ContributionReward(_contributionReward);
+        genesisProtocol = GenesisProtocol(_genesisProtocol);
+    }
+
+   /**
+    * @dev helper to redeem rewards for a proposal
+    * It calls execute on the proposal if it is not yet executed.
+    * It tries to redeem reputation and stake from the GenesisProtocol.
+    * It tries to redeem proposal rewards from the contribution rewards scheme.
+    * @param _proposalId the ID of the voting in the voting machine
+    * @param _avatar address of the controller
+    * @param _beneficiary beneficiary
+    * @return result boolean array for the following redeem types:
+    *          result[0] -execute -true or false
+    *          result[1]- redeem reputation and stakingTokens(GEN) from GenesisProtocol
+    *          result[2] -redeem daoBounty(GEN) from GenesisProtocol
+    *          result[3]- reputation - from ContributionReward
+    *          result[4]- nativeTokenReward - from ContributionReward
+    *          result[5]- Ether - from ContributionReward
+    *          result[6]- ExternalToken - from ContributionReward
+
+    */
+    function redeem(bytes32 _proposalId,address _avatar,address _beneficiary)
+    external
+    returns(bool[7] result)
+    {
+        GenesisProtocol.ProposalState pState = genesisProtocol.state(_proposalId);
+        // solium-disable-next-line operator-whitespace
+        if ((pState == GenesisProtocol.ProposalState.PreBoosted)||
+            (pState == GenesisProtocol.ProposalState.Boosted)||
+            (pState == GenesisProtocol.ProposalState.QuietEndingPeriod)) {
+            result[0] = genesisProtocol.execute(_proposalId);
+        }
+        pState = genesisProtocol.state(_proposalId);
+        if ((pState == GenesisProtocol.ProposalState.Executed) ||
+            (pState == GenesisProtocol.ProposalState.Closed)) {
+            result[1] = genesisProtocol.redeem(_proposalId,_beneficiary);
+            uint daoBountyAmount = genesisProtocol.getRedeemableTokensStakerBounty(_proposalId,_beneficiary);
+            if ((daoBountyAmount > 0) && (genesisProtocol.stakingToken().balanceOf(_avatar) >= daoBountyAmount)) {
+                result[2] = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
+            }
+            (result[3],result[4],result[5],result[6]) = contributionRewardRedeem(_proposalId,_avatar);
+        }
+        emit ARCUtilsRedeem(
+            _proposalId,
+            result[0],
+            result[1],
+            result[2],
+            result[3],
+            result[4],
+            result[5],
+            result[6]
+        );
+    }
+
+    function contributionRewardRedeem(bytes32 _proposalId,address _avatar)
+    private
+    returns (bool,bool,bool,bool)
+    {
+        bool[4] memory whatToRedeem;
+        whatToRedeem[0] = true; //reputation
+        whatToRedeem[1] = true; //nativeToken
+
+        uint periodsToPay = contributionReward.getPeriodsToPay(_proposalId,_avatar,2);
+        uint ethReward = contributionReward.getProposalEthReward(_proposalId,_avatar);
+        uint externalTokenReward = contributionReward.getProposalExternalTokenReward(_proposalId,_avatar);
+        address externalToken = contributionReward.getProposalExternalToken(_proposalId,_avatar);
+        ethReward = periodsToPay.mul(ethReward);
+        if ((ethReward == 0) || (_avatar.balance < ethReward)) {
+            whatToRedeem[2] = false;
+        } else {
+            whatToRedeem[2] = true;
+        }
+        periodsToPay = contributionReward.getPeriodsToPay(_proposalId,_avatar,3);
+        externalTokenReward = periodsToPay.mul(externalTokenReward);
+        if ((externalTokenReward == 0) || (StandardToken(externalToken).balanceOf(_avatar) < externalTokenReward)) {
+            whatToRedeem[3] = false;
+        } else {
+            whatToRedeem[3] = true;
+        }
+        whatToRedeem = contributionReward.redeem(_proposalId,_avatar,whatToRedeem);
+        return (whatToRedeem[0],whatToRedeem[1],whatToRedeem[2],whatToRedeem[3]);
+    }
+}

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -4,13 +4,13 @@ import "../universalSchemes/ContributionReward.sol";
 import "../VotingMachines/GenesisProtocol.sol";
 
 
-contract ARCUtils {
+contract Redeemer {
     using SafeMath for uint;
 
     ContributionReward public contributionReward;
     GenesisProtocol public genesisProtocol;
 
-    event ARCUtilsRedeem(bytes32 indexed _proposalId,
+    event RedeemerRedeem(bytes32 indexed _proposalId,
                  bool _execute,
                  bool _genesisProtocolRedeem,
                  bool _genesisProtocolDaoBounty,
@@ -64,7 +64,7 @@ contract ARCUtils {
             }
             (result[3],result[4],result[5],result[6]) = contributionRewardRedeem(_proposalId,_avatar);
         }
-        emit ARCUtilsRedeem(
+        emit RedeemerRedeem(
             _proposalId,
             result[0],
             result[1],

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -5,6 +5,8 @@ const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 const DaoCreator = artifacts.require("./DaoCreator.sol");
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 const Avatar = artifacts.require("./Avatar.sol");
+const ARCUtils = artifacts.require("./ARCUtils.sol");
+
 
 
 export class ContributionRewardParams {
@@ -43,20 +45,33 @@ const checkRedeemedPeriodsLeft = async function(
 const setupContributionRewardParams = async function(
                                             contributionReward,
                                             orgNativeTokenFee=0,
+                                            accounts,
+                                            genesisProtocol,
+                                            token
                                             ) {
   var contributionRewardParams = new ContributionRewardParams();
-  contributionRewardParams.votingMachine = await helpers.setupAbsoluteVote();
   contributionRewardParams.orgNativeTokenFee =  orgNativeTokenFee;
+  if (genesisProtocol === true) {
+    contributionRewardParams.votingMachine = await helpers.setupGenesisProtocol(accounts,token);
+    await contributionReward.setParameters(contributionRewardParams.orgNativeTokenFee,
+                                                 contributionRewardParams.votingMachine.params,
+                                                  contributionRewardParams.votingMachine.genesisProtocol.address);
+    contributionRewardParams.paramsHash = await contributionReward.getParametersHash(contributionRewardParams.orgNativeTokenFee,
+                                                                                     contributionRewardParams.votingMachine.params,
+                                                                                     contributionRewardParams.votingMachine.genesisProtocol.address);
+    } else {
+  contributionRewardParams.votingMachine = await helpers.setupAbsoluteVote();
   await contributionReward.setParameters(contributionRewardParams.orgNativeTokenFee,
                                          contributionRewardParams.votingMachine.params,
                                          contributionRewardParams.votingMachine.absoluteVote.address);
   contributionRewardParams.paramsHash = await contributionReward.getParametersHash(contributionRewardParams.orgNativeTokenFee,
                                                                                    contributionRewardParams.votingMachine.params,
                                                                                    contributionRewardParams.votingMachine.absoluteVote.address);
+  }
   return contributionRewardParams;
 };
 
-const setup = async function (accounts,orgNativeTokenFee=0) {
+const setup = async function (accounts,orgNativeTokenFee=0,genesisProtocol = false,tokenAddress=0) {
    var testSetup = new helpers.TestSetup();
    testSetup.fee = 10;
    testSetup.standardTokenMock = await StandardTokenMock.new(accounts[1],100);
@@ -64,9 +79,15 @@ const setup = async function (accounts,orgNativeTokenFee=0) {
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.contributionRewardParams= await setupContributionRewardParams(testSetup.contributionReward,orgNativeTokenFee);
+   testSetup.contributionRewardParams= await setupContributionRewardParams(testSetup.contributionReward,orgNativeTokenFee,accounts,genesisProtocol,tokenAddress);
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.contributionReward.address],[testSetup.contributionRewardParams.paramsHash],[permissions]);
+   if (genesisProtocol) {
+     await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,
+                                          [testSetup.contributionReward.address,testSetup.contributionRewardParams.votingMachine.genesisProtocol.address],
+                                          [testSetup.contributionRewardParams.paramsHash,testSetup.contributionRewardParams.votingMachine.params],[permissions,permissions]);
+   } else {
+     await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.contributionReward.address],[testSetup.contributionRewardParams.paramsHash],[permissions]);
+   }
    return testSetup;
 };
 contract('ContributionReward', function(accounts) {
@@ -319,7 +340,6 @@ contract('ContributionReward', function(accounts) {
              await checkRedeemedPeriods(testSetup,proposalId,0,0,0,0);
              await checkRedeemedPeriodsLeft(testSetup,proposalId,1,1,1,1);
 
-
              tx = await testSetup.contributionReward.redeem(proposalId,testSetup.org.avatar.address,[false,false,true,false]);
 
              assert.equal(tx.logs.length, 1);
@@ -467,6 +487,38 @@ contract('ContributionReward', function(accounts) {
                     await checkRedeemedPeriodsLeft(testSetup,proposalId,0,0,0,0);
 
                    });
+
+                   it("execute proposeContributionReward via genesisProtocol and redeem using ARCUtils", async function() {
+                     var standardTokenMock = await StandardTokenMock.new(accounts[0],1000);
+                     var testSetup = await setup(accounts,0,true,standardTokenMock.address);
+                     var reputationReward = 12;
+                     var nativeTokenReward = 12;
+                     var ethReward = 12;
+                     var periodLength = 50;
+                     var numberOfPeriods = 1;
+                     //send some ether to the org avatar
+                     var otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+                     web3.eth.sendTransaction({from:accounts[0],to:testSetup.org.avatar.address, value:20});
+                     var tx = await testSetup.contributionReward.proposeContributionReward(testSetup.org.avatar.address,
+                                                                                    "description",
+                                                                                    reputationReward,
+                                                                                    [nativeTokenReward,ethReward,0,periodLength,numberOfPeriods],
+                                                                                    testSetup.standardTokenMock.address,
+                                                                                    otherAvatar.address
+                                                                                  );
+                     //Vote with reputation to trigger execution
+                     var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+                     await testSetup.contributionRewardParams.votingMachine.genesisProtocol.vote(proposalId,1,{from:accounts[0]});
+                     await helpers.increaseTime(periodLength+1);
+                     var arcUtils = await ARCUtils.new(testSetup.contributionReward.address,testSetup.contributionRewardParams.votingMachine.genesisProtocol.address);
+                     await arcUtils.redeem(proposalId,testSetup.org.avatar.address,accounts[0]);
+                     var eth = web3.eth.getBalance(otherAvatar.address);
+                     assert.equal(eth.toNumber(),ethReward);
+                     assert.equal(await testSetup.org.reputation.reputationOf(otherAvatar.address),reputationReward);
+                     assert.equal(await testSetup.org.token.balanceOf(otherAvatar.address),nativeTokenReward);
+                     var reputation = await testSetup.org.reputation.reputationOf(accounts[0]);
+                     assert.equal(reputation,1141);
+                    });
 
 
 });

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -5,7 +5,7 @@ const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 const DaoCreator = artifacts.require("./DaoCreator.sol");
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 const Avatar = artifacts.require("./Avatar.sol");
-const ARCUtils = artifacts.require("./ARCUtils.sol");
+const Redeemer = artifacts.require("./Redeemer.sol");
 
 
 
@@ -488,7 +488,7 @@ contract('ContributionReward', function(accounts) {
 
                    });
 
-                   it("execute proposeContributionReward via genesisProtocol and redeem using ARCUtils", async function() {
+                   it("execute proposeContributionReward via genesisProtocol and redeem using Redeemer", async function() {
                      var standardTokenMock = await StandardTokenMock.new(accounts[0],1000);
                      var testSetup = await setup(accounts,0,true,standardTokenMock.address);
                      var reputationReward = 12;
@@ -510,7 +510,7 @@ contract('ContributionReward', function(accounts) {
                      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
                      await testSetup.contributionRewardParams.votingMachine.genesisProtocol.vote(proposalId,1,{from:accounts[0]});
                      await helpers.increaseTime(periodLength+1);
-                     var arcUtils = await ARCUtils.new(testSetup.contributionReward.address,testSetup.contributionRewardParams.votingMachine.genesisProtocol.address);
+                     var arcUtils = await Redeemer.new(testSetup.contributionReward.address,testSetup.contributionRewardParams.votingMachine.genesisProtocol.address);
                      await arcUtils.redeem(proposalId,testSetup.org.avatar.address,accounts[0]);
                      var eth = web3.eth.getBalance(otherAvatar.address);
                      assert.equal(eth.toNumber(),ethReward);


### PR DESCRIPTION
This helper redeem function can be use to execute and redeem proposals in one transaction from both GenesisProtocol and ContributionRewards.

The redeem function :
- calls execute on the proposal if it is not yet executed.
 -tries to redeem reputation and stake from the GenesisProtocol.
 -tries to redeem DAOBounty from the GenesisProtocol.
 -tries to redeem proposal rewards from the contribution rewards scheme.

