### PR TITLE
Use node version >= 8.11.3 (Recommended) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 
 node_js:
-  - "9.10.0"
+  - "8.11.3"
 
 before_install:
   - sudo apt-get update -qq

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "arc"
   ],
   "engines": {
-    "node": ">=9.10.0"
+    "node": ">=8.11.3"
   },
   "author": "DAOstack (https://www.daostack.io)",
   "license": "GPL-3.0",


### PR DESCRIPTION
Use recommended  node version >= 8.11.3 
which is recommended for most users by  [node.js](https://nodejs.org/en/). 
fix issue #497 
