### PR TITLE
add fix reputation scheme

### DIFF
--- a/contracts/schemes/FixReputationAllocation.sol
+++ b/contracts/schemes/FixReputationAllocation.sol
@@ -1,0 +1,95 @@
+pragma solidity ^0.4.24;
+
+import "../controller/ControllerInterface.sol";
+import { RealMath } from "../libs/RealMath.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+
+
+/**
+ * @title A fixed reputation allocation contract
+ */
+
+contract FixedReputationAllocation is Ownable {
+    using SafeMath for uint;
+    using RealMath for int216;
+    using RealMath for int256;
+
+    event Redeem(address indexed _beneficiary,uint _amount);
+    event BeneficiaryAddressAdded(address _beneficiary);
+
+    // beneficiary -> exist
+    mapping(address=>bool) public beneficiaries;
+
+    Avatar public avatar;
+    uint public reputationReward;
+    bool public isEnable;
+    uint public numberOfBeneficiaries;
+    uint public beneficiaryReward;
+
+    /**
+     * @dev constructor
+     * @param _avatar the avatar to mint reputation from
+     * @param _reputationReward the total reputation this contract will reward
+     */
+    constructor(Avatar _avatar,
+                uint _reputationReward)
+    public
+    {
+        reputationReward = _reputationReward;
+        avatar = _avatar;
+    }
+
+    /**
+     * @dev redeem reputation function
+     * @param _beneficiary the beneficiary for the release
+     * @return bool
+     */
+    function redeem(address _beneficiary) public returns(bool) {
+        require(isEnable,"require to be enable");
+        require(beneficiaries[_beneficiary],"require _beneficiary to exist in the beneficiaries map");
+        require(ControllerInterface(avatar.owner()).mintReputation(beneficiaryReward,_beneficiary,avatar),"mint reputation should success");
+        emit Redeem(_beneficiary,beneficiaryReward);
+        return true;
+    }
+
+    /**
+     * @dev addBeneficiary function
+     * @param _beneficiary to be whitelisted
+     */
+    function addBeneficiary(address _beneficiary)
+    public
+    onlyOwner
+    {
+        require(!isEnable,"can add beneficiary only if not already enable");
+        if (!beneficiaries[_beneficiary]) {
+            beneficiaries[_beneficiary] = true;
+            numberOfBeneficiaries++;
+            emit BeneficiaryAddressAdded(_beneficiary);
+        }
+    }
+
+    /**
+     * @dev add addBeneficiaries function
+     * @param _beneficiaries addresses
+     */
+    function addBeneficiaries(address[] _beneficiaries)
+    public
+    onlyOwner
+    {
+        for (uint256 i = 0; i < _beneficiaries.length; i++) {
+            addBeneficiary(_beneficiaries[i]);
+        }
+    }
+
+    /**
+     * @dev enable function
+     */
+    function enable()
+    public
+    onlyOwner
+    {
+        isEnable = true;
+        //Calculate beneficiary reward
+        beneficiaryReward = uint256(int216(reputationReward).div(int256(numberOfBeneficiaries)).fromReal());
+    }
+}

--- a/contracts/schemes/FixReputationAllocation.sol
+++ b/contracts/schemes/FixReputationAllocation.sol
@@ -7,6 +7,8 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**
  * @title A fixed reputation allocation contract
+ * This scheme can be used to allocate a pre define amount of reputation to whitelisted
+ * beneficiaries.
  */
 
 contract FixedReputationAllocation is Ownable {

--- a/test/fixreputationallocation.js
+++ b/test/fixreputationallocation.js
@@ -1,0 +1,105 @@
+const helpers = require('./helpers');
+const DaoCreator = artifacts.require("./DaoCreator.sol");
+const ControllerCreator = artifacts.require("./ControllerCreator.sol");
+const constants = require('./constants');
+var FixedReputationAllocation = artifacts.require("./FixedReputationAllocation.sol");
+
+const setup = async function (accounts,_repAllocation = 300) {
+   var testSetup = new helpers.TestSetup();
+   var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
+   testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
+   testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],0,0);
+
+   testSetup.fixedReputationAllocation = await FixedReputationAllocation.new(testSetup.org.avatar.address,
+                                                                            _repAllocation);
+
+   var permissions = "0x00000000";
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.fixedReputationAllocation.address],[0],[permissions]);
+   return testSetup;
+};
+
+contract('FixedReputationAllocation', accounts => {
+    it("constructor", async () => {
+      let testSetup = await setup(accounts);
+      assert.equal(await testSetup.fixedReputationAllocation.reputationReward(),300);
+      assert.equal(await testSetup.fixedReputationAllocation.isEnable(),false);
+    });
+
+    it("add beneficiary", async () => {
+       let testSetup = await setup(accounts);
+       let tx = await testSetup.fixedReputationAllocation.addBeneficiary(accounts[0]);
+       assert.equal(tx.logs.length,1);
+       assert.equal(tx.logs[0].event,"BeneficiaryAddressAdded");
+       assert.equal(tx.logs[0].args._beneficiary,accounts[0]);
+    });
+
+    it("add beneficiary check only owner", async () => {
+       let testSetup = await setup(accounts);
+       try {
+         await testSetup.fixedReputationAllocation.addBeneficiary(accounts[0],{from: accounts[1]});
+         assert(false, "addBeneficiary is only owner");
+       } catch(error) {
+         helpers.assertVMException(error);
+       }
+    });
+
+    it("add beneficiaries", async () => {
+      let testSetup = await setup(accounts);
+      let tx = await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
+      assert.equal(tx.logs.length,accounts.length);
+    });
+
+    it("redeem", async () => {
+      let testSetup = await setup(accounts);
+      let tx = await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
+      assert.equal(await testSetup.fixedReputationAllocation.numberOfBeneficiaries(),accounts.length);
+      assert.equal(await testSetup.fixedReputationAllocation.beneficiaryReward(),0);
+      await testSetup.fixedReputationAllocation.enable();
+      assert.equal(await testSetup.fixedReputationAllocation.beneficiaryReward(),300/accounts.length);
+      var beneficiaryReward;
+      var reputation;
+      for (var i = 0 ;i< accounts.length ;i++) {
+          tx = await testSetup.fixedReputationAllocation.redeem(accounts[i]);
+          assert.equal(tx.logs.length,1);
+          assert.equal(tx.logs[0].event,"Redeem");
+          beneficiaryReward = await testSetup.fixedReputationAllocation.beneficiaryReward();
+          assert.equal(tx.logs[0].args._amount,beneficiaryReward.toNumber());
+          reputation = await testSetup.org.reputation.reputationOf(accounts[i]);
+          assert.equal(reputation.toNumber(),tx.logs[0].args._amount);
+      }
+    });
+
+    it("redeem without enable should revert", async () => {
+      let testSetup = await setup(accounts);
+      await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
+      try {
+        await testSetup.fixedReputationAllocation.redeem(accounts[0]);
+        assert(false, "redeem without enable should revert");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+    });
+
+    it("redeem from none white listed beneficiary should revert", async () => {
+      let testSetup = await setup(accounts);
+      await testSetup.fixedReputationAllocation.addBeneficiary(accounts[0]);
+      await testSetup.fixedReputationAllocation.enable();
+      try {
+        await testSetup.fixedReputationAllocation.redeem(accounts[1]);
+        assert(false, "redeem from none white listed beneficiary should revert");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+    });
+
+    it("enable is onlyOwner", async () => {
+      let testSetup = await setup(accounts);
+      await testSetup.fixedReputationAllocation.addBeneficiary(accounts[0]);
+      try {
+        await testSetup.fixedReputationAllocation.enable({from:accounts[1]});
+        assert(false, "enable is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+    });
+});


### PR DESCRIPTION
This scheme can be used to allocate a pre define amount of reputation to whitelisted beneficiaries.

