### PR TITLE
GenesisProtocol - optimise redeem function

### DIFF
--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -326,7 +326,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
 
     /**
     * @dev proposalStatus return the total votes and stakes for a given proposal
-    * @param _proposalId the ID of the proposalt
+    * @param _proposalId the ID of the proposal
     * @return uint preBoostedVotes YES
     * @return uint preBoostedVotes NO
     * @return uint stakersStakes

--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -455,19 +455,21 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
         //as voter
         Voter storage voter = proposal.voters[_beneficiary];
         if (voter.reputation != 0 ) {
-            if (proposal.votesCount[0] > 0) {
-                if ((voter.preBoosted)&&(proposal.votesCount[1]>0)) {
-                    amount += ((proposal.votersStakes * voter.reputation) / proposal.votesCount[1]);
-                }
-                if (proposal.state == ProposalState.Closed) {
-                    //no reputation flow occurs so give back reputation for the voter
-                    reputation += ((voter.reputation * params.votersReputationLossRatio)/100);
-                } else if (proposal.voters[_beneficiary].preBoosted && (proposal.winningVote == proposal.voters[_beneficiary].vote )) {
-                     //give back reputation for the voter
+
+            if ((voter.preBoosted)&&(proposal.votesCount[1]>0)) {
+                amount += ((proposal.votersStakes * voter.reputation) / proposal.votesCount[1]);
+            }
+            if (proposal.state == ProposalState.Closed) {
+                //no reputation flow occurs so give back reputation for the voter
+                reputation += ((voter.reputation * params.votersReputationLossRatio)/100);
+            } else {
+                if (proposal.voters[_beneficiary].preBoosted && (proposal.winningVote == proposal.voters[_beneficiary].vote )) {
+                 //give back reputation for the voter
                     reputation += (voter.reputation * params.votersReputationLossRatio)/100;
-                }
+              }
                 reputation += (voter.reputation * ((proposal.lostReputation * params.votersGainRepRatioFromLostRep)/100)/proposal.votesCount[0]);
             }
+
             proposal.voters[_beneficiary].reputation = 0;
         }
         //as proposer

--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -332,7 +332,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
     * @return uint stakersStakes
     * @return uint totalRedeemableStakes
     * @return uint total stakes YES
-    * @return uint total stakes NO 
+    * @return uint total stakes NO
     */
     function proposalStatus(bytes32 _proposalId) external view returns(uint, uint, uint ,uint, uint ,uint) {
         return (
@@ -442,6 +442,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
         } else {
             lostReputation = proposal.preBoostedVotes[YES];
         }
+        lostReputation = (lostReputation * params.votersReputationLossRatio)/100;
         //as staker
         if ((proposal.stakers[_beneficiary].amount>0) &&
              (proposal.stakers[_beneficiary].vote == proposal.winningVote)) {
@@ -467,7 +468,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
                     reputation += ((voter.reputation * params.votersReputationLossRatio)/100);
                 } else if (proposal.winningVote == proposal.voters[_beneficiary].vote ) {
                     reputation += (((voter.reputation * params.votersReputationLossRatio)/100) +
-                    (voter.reputation * ((lostReputation * params.votersGainRepRatioFromLostRep)/100)/preBoostedVotes));
+                    (((voter.reputation * lostReputation * params.votersGainRepRatioFromLostRep)/100)/preBoostedVotes));
                 }
             }
             proposal.voters[_beneficiary].reputation = 0;

--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -379,7 +379,7 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
     }
 
     /**
-      * @dev voteStake return the state for a given proposal
+      * @dev state return the state for a given proposal
       * @param _proposalId the ID of the proposal
       * @return ProposalState proposal state
     */

--- a/contracts/universalSchemes/ContributionReward.sol
+++ b/contracts/universalSchemes/ContributionReward.sol
@@ -401,4 +401,8 @@ contract ContributionReward is UniversalScheme {
         return organizationsProposals[_avatar][_proposalId].externalToken;
     }
 
+    function getProposalExecutionTime(bytes32 _proposalId, address _avatar) public view returns (uint) {
+        return organizationsProposals[_avatar][_proposalId].executionTime;
+    }
+
 }

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -34,11 +34,11 @@ contract Redeemer {
     *          gpRewards[4] - proposerReputationAmount
     * @return gpDaoBountyReward
     * @return executed bool true or false
-    * @return crResult array
-    *          crResults[3]- reputation - from ContributionReward
-    *          crResults[4]- nativeTokenReward - from ContributionReward
-    *          crResults[5]- Ether - from ContributionReward
-    *          crResults[6]- ExternalToken - from ContributionReward
+    * @return crResults array
+    *          crResults[0]- reputation - from ContributionReward
+    *          crResults[1]- nativeTokenReward - from ContributionReward
+    *          crResults[2]- Ether - from ContributionReward
+    *          crResults[3]- ExternalToken - from ContributionReward
 
     */
     function redeem(bytes32 _proposalId,address _avatar,address _beneficiary)

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -32,7 +32,10 @@ contract Redeemer {
     *          gpRewards[2] - voterTokenAmount
     *          gpRewards[3] - voterReputationAmount
     *          gpRewards[4] - proposerReputationAmount
-    * @return gpDaoBountyReward
+    * @return gpDaoBountyReward array
+    *         gpDaoBountyReward[0] - staker dao bounty reward -
+    *                                will be zero for the case there is not enough tokens in avatar for the reward.
+    *         gpDaoBountyReward[1] - staker potential dao bounty reward.
     * @return executed bool true or false
     * @return crResults array
     *          crResults[0]- reputation - from ContributionReward
@@ -44,7 +47,7 @@ contract Redeemer {
     function redeem(bytes32 _proposalId,address _avatar,address _beneficiary)
     external
     returns(uint[5] gpRewards,
-            uint gpDaoBountyReward,
+            uint[2] gpDaoBountyReward,
             bool executed,
             bool[4] crResults)
     {
@@ -59,7 +62,7 @@ contract Redeemer {
         if ((pState == GenesisProtocol.ProposalState.Executed) ||
             (pState == GenesisProtocol.ProposalState.Closed)) {
             gpRewards = genesisProtocol.redeem(_proposalId,_beneficiary);
-            (gpDaoBountyReward,gpDaoBountyReward) = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
+            (gpDaoBountyReward[0],gpDaoBountyReward[1]) = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
             //}
             //redeem from contributionReward only if it is positive decision
             if (genesisProtocol.winningVote(_proposalId) == genesisProtocol.YES()) {

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -38,8 +38,7 @@ contract Redeemer {
     */
     function redeem(bytes32 _proposalId,address _avatar,address _beneficiary)
     external
-    returns(uint gpTokenReward,
-            uint gpRepReward,
+    returns(uint[5] gpRewards,
             uint gpDaoBountyReward,
             bool executed,
             bool[4] crResult)
@@ -54,9 +53,7 @@ contract Redeemer {
         pState = genesisProtocol.state(_proposalId);
         if ((pState == GenesisProtocol.ProposalState.Executed) ||
             (pState == GenesisProtocol.ProposalState.Closed)) {
-            uint[5] memory rewards = genesisProtocol.redeem(_proposalId,_beneficiary);
-            gpTokenReward = rewards[0] + rewards[2];
-            gpRepReward = rewards[1] + rewards[3] + rewards[4];
+            gpRewards = genesisProtocol.redeem(_proposalId,_beneficiary);
             (gpDaoBountyReward,gpDaoBountyReward) = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
             //}
             //redeem from contributionReward only if it is positive decision

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -26,14 +26,19 @@ contract Redeemer {
     * @param _proposalId the ID of the voting in the voting machine
     * @param _avatar address of the controller
     * @param _beneficiary beneficiary
-    * @return result boolean array for the following redeem types:
-    *          result[0] -execute -true or false
-    *          result[1]- redeem reputation and stakingTokens(GEN) from GenesisProtocol
-    *          result[2] -redeem daoBounty(GEN) from GenesisProtocol
-    *          result[3]- reputation - from ContributionReward
-    *          result[4]- nativeTokenReward - from ContributionReward
-    *          result[5]- Ether - from ContributionReward
-    *          result[6]- ExternalToken - from ContributionReward
+    * @return gpRewards array
+    *          gpRewards[0] - stakerTokenAmount
+    *          gpRewards[1] - stakerReputationAmount
+    *          gpRewards[2] - voterTokenAmount
+    *          gpRewards[3] - voterReputationAmount
+    *          gpRewards[4] - proposerReputationAmount
+    * @return gpDaoBountyReward
+    * @return executed bool true or false
+    * @return crResult array
+    *          crResults[3]- reputation - from ContributionReward
+    *          crResults[4]- nativeTokenReward - from ContributionReward
+    *          crResults[5]- Ether - from ContributionReward
+    *          crResults[6]- ExternalToken - from ContributionReward
 
     */
     function redeem(bytes32 _proposalId,address _avatar,address _beneficiary)
@@ -41,7 +46,7 @@ contract Redeemer {
     returns(uint[5] gpRewards,
             uint gpDaoBountyReward,
             bool executed,
-            bool[4] crResult)
+            bool[4] crResults)
     {
         GenesisProtocol.ProposalState pState = genesisProtocol.state(_proposalId);
         // solium-disable-next-line operator-whitespace
@@ -58,7 +63,7 @@ contract Redeemer {
             //}
             //redeem from contributionReward only if it is positive decision
             if (genesisProtocol.winningVote(_proposalId) == genesisProtocol.YES()) {
-                (crResult[0],crResult[1],crResult[2],crResult[3]) = contributionRewardRedeem(_proposalId,_avatar);
+                (crResults[0],crResults[1],crResults[2],crResults[3]) = contributionRewardRedeem(_proposalId,_avatar);
             }
         }
     }

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -63,9 +63,8 @@ contract Redeemer {
             (pState == GenesisProtocol.ProposalState.Closed)) {
             gpRewards = genesisProtocol.redeem(_proposalId,_beneficiary);
             (gpDaoBountyReward[0],gpDaoBountyReward[1]) = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
-            //}
-            //redeem from contributionReward only if it is positive decision
-            if (genesisProtocol.winningVote(_proposalId) == genesisProtocol.YES()) {
+            //redeem from contributionReward only if it executed
+            if (contributionReward.getProposalExecutionTime(_proposalId,_avatar) > 0) {
                 (crResults[0],crResults[1],crResults[2],crResults[3]) = contributionRewardRedeem(_proposalId,_avatar);
             }
         }
@@ -78,7 +77,6 @@ contract Redeemer {
         bool[4] memory whatToRedeem;
         whatToRedeem[0] = true; //reputation
         whatToRedeem[1] = true; //nativeToken
-
         uint periodsToPay = contributionReward.getPeriodsToPay(_proposalId,_avatar,2);
         uint ethReward = contributionReward.getProposalEthReward(_proposalId,_avatar);
         uint externalTokenReward = contributionReward.getProposalExternalTokenReward(_proposalId,_avatar);

--- a/contracts/utils/Redeemer.sol
+++ b/contracts/utils/Redeemer.sol
@@ -54,9 +54,9 @@ contract Redeemer {
         pState = genesisProtocol.state(_proposalId);
         if ((pState == GenesisProtocol.ProposalState.Executed) ||
             (pState == GenesisProtocol.ProposalState.Closed)) {
-            (gpTokenReward,gpRepReward) = genesisProtocol.redeem(_proposalId,_beneficiary);
-            /*uint daoBountyAmount = genesisProtocol.getRedeemableTokensStakerBounty(_proposalId,_beneficiary);
-            if ((daoBountyAmount > 0) && (genesisProtocol.stakingToken().balanceOf(_avatar) >= daoBountyAmount)) {*/
+            uint[5] memory rewards = genesisProtocol.redeem(_proposalId,_beneficiary);
+            gpTokenReward = rewards[0] + rewards[2];
+            gpRepReward = rewards[1] + rewards[3] + rewards[4];
             (gpDaoBountyReward,gpDaoBountyReward) = genesisProtocol.redeemDaoBounty(_proposalId,_beneficiary);
             //}
             //redeem from contributionReward only if it is positive decision

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tsconfig.json"
   ],
   "config": {
-    "gasLimit": "6100000"
+    "gasLimit": "5900000"
   },
   "scripts": {
     "test": "cross-conf-env run-with-ganache --ganache-cmd 'npm run ganache' 'npm run truffle compile && npm run truffle migrate && npm run truffle test'",

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,3 +1,3 @@
-const ARC_GAS_LIMIT = 6100000;
+const ARC_GAS_LIMIT = 5900000;
 
 module.exports = { ARC_GAS_LIMIT };

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -510,13 +510,18 @@ contract('ContributionReward', function(accounts) {
      await testSetup.contributionRewardParams.votingMachine.genesisProtocol.vote(proposalId,1,{from:accounts[0]});
      await helpers.increaseTime(periodLength+1);
      var arcUtils = await Redeemer.new(testSetup.contributionReward.address,testSetup.contributionRewardParams.votingMachine.genesisProtocol.address);
+     var redeemRewards = await arcUtils.redeem.call(proposalId,testSetup.org.avatar.address,accounts[0]);
+     assert.equal(redeemRewards[0][3],100); //redeemRewards[0] gpRewards
+     assert.equal(redeemRewards[0][4],61);
+     assert.equal(redeemRewards[1],0); //daoBountyRewards
+     assert.equal(redeemRewards[2],false); //isExecuted
+     assert.equal(redeemRewards[3][0],true); //redeemRewards[3] crResultArray
      await arcUtils.redeem(proposalId,testSetup.org.avatar.address,accounts[0]);
      var eth = web3.eth.getBalance(otherAvatar.address);
      assert.equal(eth.toNumber(),ethReward);
      assert.equal(await testSetup.org.reputation.reputationOf(otherAvatar.address),reputationReward);
      assert.equal(await testSetup.org.token.balanceOf(otherAvatar.address),nativeTokenReward);
      var reputation = await testSetup.org.reputation.reputationOf(accounts[0]);
-
      var reputationGainAsVoter =  0;
      var proposingRepRewardConstA=60;
      var proposingRepRewardConstB=1;

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -513,7 +513,8 @@ contract('ContributionReward', function(accounts) {
      var redeemRewards = await arcUtils.redeem.call(proposalId,testSetup.org.avatar.address,accounts[0]);
      assert.equal(redeemRewards[0][3],100); //redeemRewards[0] gpRewards
      assert.equal(redeemRewards[0][4],61);
-     assert.equal(redeemRewards[1],0); //daoBountyRewards
+     assert.equal(redeemRewards[1][0],0); //daoBountyRewards
+     assert.equal(redeemRewards[1][1],0); //daoBountyRewards
      assert.equal(redeemRewards[2],false); //isExecuted
      assert.equal(redeemRewards[3][0],true); //redeemRewards[3] crResultArray
      await arcUtils.redeem(proposalId,testSetup.org.avatar.address,accounts[0]);

--- a/test/contributionreward.js
+++ b/test/contributionreward.js
@@ -516,7 +516,12 @@ contract('ContributionReward', function(accounts) {
      assert.equal(await testSetup.org.reputation.reputationOf(otherAvatar.address),reputationReward);
      assert.equal(await testSetup.org.token.balanceOf(otherAvatar.address),nativeTokenReward);
      var reputation = await testSetup.org.reputation.reputationOf(accounts[0]);
-     assert.equal(reputation,1141);
+
+     var reputationGainAsVoter =  0;
+     var proposingRepRewardConstA=60;
+     var proposingRepRewardConstB=1;
+     var reputationGainAsProposer = (proposingRepRewardConstA*1000 + proposingRepRewardConstB*1000)/1000;
+     assert.equal(reputation, 1000+reputationGainAsVoter + reputationGainAsProposer);
     });
     it("execute proposeContributionReward via genesisProtocol and redeem using Redeemer for negative proposal", async function() {
       var standardTokenMock = await StandardTokenMock.new(accounts[0],1000);
@@ -547,9 +552,11 @@ contract('ContributionReward', function(accounts) {
       assert.equal(await testSetup.org.reputation.reputationOf(otherAvatar.address),0);
       assert.equal(await testSetup.org.token.balanceOf(otherAvatar.address),0);
       var reputation = await testSetup.org.reputation.reputationOf(accounts[0]);
-      assert.equal(reputation,1080);
+      //no reputation reward for proposer for negative proposal.
+      //reputation reward for a single voter = 0
+      assert.equal(reputation, 1000);
      });
-     
+
     it("execute proposeContributionReward  mint reputation with period 0 ", async function() {
        var testSetup = await setup(accounts);
        var reputationReward = 12;

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -270,7 +270,6 @@ contract('GenesisProtocol', function (accounts) {
       await testSetup.genesisProtocol.vote(proposalId, 1);
 
       winningVote = 1;
-      lostReputation = (10 * testSetup.reputationArray[0])/100; //10 % of testSetup.reputationArray[0]
       var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
       assert.equal(testSetup.reputationArray[0],proposalStatus[0]);
       assert.equal(0,proposalStatus[1]);
@@ -294,7 +293,6 @@ contract('GenesisProtocol', function (accounts) {
       // another minority reputation (Option 0):
       await testSetup.genesisProtocol.vote(proposalId, 2, { from: accounts[1] });
       await checkVoteInfo(proposalId, accounts[1], [2, testSetup.reputationArray[1]],testSetup.genesisProtocol);
-      lostReputation += (10 * testSetup.reputationArray[1])/100;
       proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
       assert.equal(testSetup.reputationArray[0],proposalStatus[0]);
       assert.equal(testSetup.reputationArray[1],proposalStatus[1]);

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1469,12 +1469,10 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
 
       await testSetup.genesisProtocol.execute(proposalId);
-      await helpers.increaseTime(100); //increase time
+
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
       assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
-
-      assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[proposalStateIndex],2);//executed

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1279,7 +1279,7 @@ contract('GenesisProtocol', function (accounts) {
     await helpers.increaseTime(61);
     await testSetup.genesisProtocol.execute(proposalId);
     var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,accounts[0]);
-    var redeemToken = redeemRewards[0];
+    var redeemToken = redeemRewards[0].toNumber() + redeemRewards[2].toNumber();
     assert.equal(redeemToken,10+90);
     assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
     var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
@@ -1291,7 +1291,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(tx.logs[0].event, "Redeem");
     assert.equal(tx.logs[0].args._proposalId, proposalId);
     assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
-    assert.equal(tx.logs[0].args._amount, redeemToken.toNumber());
+    assert.equal(tx.logs[0].args._amount, redeemToken);
     assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),1000);
   });
 
@@ -1321,13 +1321,13 @@ contract('GenesisProtocol', function (accounts) {
       let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
       var proposalId = await getValueFromLogs(tx, '_proposalId');
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
+      assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
       await testSetup.genesisProtocol.vote(proposalId,YES);
       await stake(testSetup,proposalId,YES,100,accounts[0]);
 
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),1);
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),2);
       //set up another proposal
       tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
@@ -1336,7 +1336,7 @@ contract('GenesisProtocol', function (accounts) {
       await testSetup.genesisProtocol.vote(proposalId,YES);
       await stake(testSetup,proposalId,YES,100,accounts[0]);
       assert.equal(await testSetup.genesisProtocol.state(proposalId),4);
-      var numberOfBoostedProposals = await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address);
+      var numberOfBoostedProposals = await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address);
       assert.equal(numberOfBoostedProposals,2);
 
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),4);
@@ -1389,8 +1389,8 @@ contract('GenesisProtocol', function (accounts) {
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
       var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,voterY);
-      var redeemToken = redeemRewards[0];
-      var RedeemReputation = redeemRewards[1];
+      var redeemToken = redeemRewards[0].toNumber() + redeemRewards[2].toNumber();
+      var RedeemReputation = redeemRewards[1].toNumber() + redeemRewards[3].toNumber() + redeemRewards[4].toNumber();
       var repVoterY = testSetup.reputationArray[0];
       var repVoterN = testSetup.reputationArray[1];
       var preBoostedVotes = repVoterY + repVoterN;
@@ -1403,12 +1403,12 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(tx.logs[0].event, "Redeem");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
       assert.equal(tx.logs[0].args._beneficiary, voterY);
-      assert.equal(tx.logs[0].args._amount, redeemToken.toNumber());
+      assert.equal(tx.logs[0].args._amount, redeemToken);
       assert.equal(tx.logs[1].event, "RedeemReputation");
       assert.equal(tx.logs[1].args._proposalId, proposalId);
       assert.equal(tx.logs[1].args._beneficiary, voterY);
-      assert.equal(tx.logs[1].args._amount, RedeemReputation.toNumber());
-      assert.equal(await testSetup.stakingToken.balanceOf(voterY),500+redeemToken.toNumber());
+      assert.equal(tx.logs[1].args._amount, RedeemReputation);
+      assert.equal(await testSetup.stakingToken.balanceOf(voterY),500+redeemToken);
       assert.equal(await testSetup.org.reputation.reputationOf(voterY),Math.round(repVoterY+(repVoterY *((lostReputation*votersGainRepRatioFromLostRep)/100)/ preBoostedVotes)));
     });
 
@@ -1423,17 +1423,17 @@ contract('GenesisProtocol', function (accounts) {
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
       var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,accounts[0]);
-      var totalRep = redeemRewards[1];
+      var totalRep = redeemRewards[1].toNumber() + redeemRewards[3].toNumber() +redeemRewards[4].toNumber();
       tx = await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
       assert.equal(tx.logs.length, 1);
       assert.equal(tx.logs[0].event, "RedeemReputation");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
       assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
       //var totalRep =  rep4Stake.toNumber() + rep4Vote.toNumber() + rep4Propose.toNumber();
-      assert.equal(tx.logs[0].args._amount, totalRep.toNumber());
+      assert.equal(tx.logs[0].args._amount, totalRep);
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),1000);
       var loss = (10*testSetup.reputationArray[0])/100;  //votersReputationLossRatio
-      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + totalRep.toNumber() - loss);
+      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + totalRep - loss);
     });
 
     it("quite window ", async () => {
@@ -1466,13 +1466,13 @@ contract('GenesisProtocol', function (accounts) {
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
       assert.equal(proposalInfo[proposalStateIndex],5);//boosted -still not execute
       await helpers.increaseTime(10); //increase time
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
+      assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
 
       await testSetup.genesisProtocol.execute(proposalId);
       await helpers.increaseTime(100); //increase time
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
-      assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
+      assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
 
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
@@ -1594,10 +1594,10 @@ contract('GenesisProtocol', function (accounts) {
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
     assert.equal(proposalInfo[proposalStateIndex],5);//quiteEndperiod
     await helpers.increaseTime(10); //increase time
-    assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
+    assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),1);
     //vote NO to toggle direction again and extend the quite end period
     await testSetup.genesisProtocol.vote(proposalId,2,{from:accounts[2]}); //change winning vote and execute
-    assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),0);
+    assert.equal(await testSetup.genesisProtocol.getBoostedProposalsCount(testSetup.org.avatar.address),0);
     //increase time after the proposal expiration
     await helpers.increaseTime(61); //increase time
     assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
@@ -1628,8 +1628,8 @@ contract('GenesisProtocol', function (accounts) {
     var votersStakes = proposalInfo[proposalVotersStakesIndex];
     var preBoostedVotes = proposalStatus[1]+proposalStatus[0];
     assert.equal(preBoostedVotes,testSetup.reputationArray[0]);
-    assert.equal(redeemValues[0].toNumber(),votersStakes.toNumber()*testSetup.reputationArray[0]/preBoostedVotes);
-    assert.equal(redeemValues[0].toNumber(),10);
+    assert.equal(redeemValues[2].toNumber(),votersStakes.toNumber()*testSetup.reputationArray[0]/preBoostedVotes);
+    assert.equal(redeemValues[2].toNumber(),10);
   });
 
   it("boosted voters are not rewarded from staker", async () => {
@@ -1655,7 +1655,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(votersStakes,10);
     var preBoostedVotes = proposalStatus[1];
     assert.equal(preBoostedVotes,0);
-    assert.equal(redeemValues[0].toNumber(),0);
+    assert.equal(redeemValues[2].toNumber(),0);
   });
 
 

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -934,7 +934,7 @@ contract('GenesisProtocol', function (accounts) {
     let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
     var proposalId = await getValueFromLogs(tx, '_proposalId');
     assert.isOk(proposalId);
-    let staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    let staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],0);
     assert.equal(staker[1],0);
 
@@ -944,7 +944,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(tx[0].args._staker, accounts[0]);
     assert.equal(tx[0].args._vote, 1);
     assert.equal(tx[0].args._amount, 10);
-    staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],1);
     assert.equal(staker[1],10);
      nonce--;
@@ -971,7 +971,7 @@ contract('GenesisProtocol', function (accounts) {
     let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
     var proposalId = await getValueFromLogs(tx, '_proposalId');
     assert.isOk(proposalId);
-    let staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    let staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],0);
     assert.equal(staker[1],0);
     var textMsg = "0x"+ethereumjs.soliditySHA3(
@@ -998,7 +998,7 @@ contract('GenesisProtocol', function (accounts) {
     let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
     var proposalId = await getValueFromLogs(tx, '_proposalId');
     assert.isOk(proposalId);
-    let staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    let staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],0);
     assert.equal(staker[1],0);
     var textMsg = "0x"+ethereumjs.soliditySHA3(
@@ -1024,7 +1024,7 @@ contract('GenesisProtocol', function (accounts) {
     let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,accounts[0]);
     var proposalId = await getValueFromLogs(tx, '_proposalId');
     assert.isOk(proposalId);
-    let staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    let staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],0);
     assert.equal(staker[1],0);
 
@@ -1034,7 +1034,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(tx[0].args._staker, accounts[0]);
     assert.equal(tx[0].args._vote, 1);
     assert.equal(tx[0].args._amount, 10);
-    staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],1);
     assert.equal(staker[1],10);
 
@@ -1045,7 +1045,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(tx[0].args._staker, accounts[0]);
     assert.equal(tx[0].args._vote, 1);
     assert.equal(tx[0].args._amount, 10);
-    staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],1);
     assert.equal(staker[1],20);
 
@@ -1053,7 +1053,7 @@ contract('GenesisProtocol', function (accounts) {
 
     tx = await stake(testSetup,proposalId,2,10,accounts[0]);
     assert.equal(tx.length, 0);
-    staker = await testSetup.genesisProtocol.staker(proposalId,accounts[0]);
+    staker = await testSetup.genesisProtocol.getStaker(proposalId,accounts[0]);
     assert.equal(staker[0],1);
     assert.equal(staker[1],20);
 

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -128,25 +128,27 @@ const checkProposalInfo = async function(proposalId, _proposalInfo,genesisProtoc
   assert.equal(proposalInfo[1], _proposalInfo[1]);
     // ExecutableInterface executable;
   assert.equal(proposalInfo[2], _proposalInfo[2]);
-  // totalVotes
-  assert.equal(proposalInfo[3], _proposalInfo[3]);
     // votersStakes
+  assert.equal(proposalInfo[3], _proposalInfo[3]);
+  //lostReputation
   assert.equal(proposalInfo[4], _proposalInfo[4]);
-    //lostReputation
-  assert.equal(proposalInfo[5], _proposalInfo[5]);
   //submittedTime; for now do not test for submittedTime
+  assert.equal(proposalInfo[5], _proposalInfo[5]);
+    //boostedPhaseTime;
   assert.equal(proposalInfo[6], _proposalInfo[6]);
-  //boostedPhaseTime;
-  assert.equal(proposalInfo[7], _proposalInfo[7]);
   //state
-  assert.equal(proposalInfo[8], _proposalInfo[8]);
+  assert.equal(proposalInfo[7], _proposalInfo[7]);
   //winningVote
-  assert.equal(proposalInfo[9], _proposalInfo[9]);
+  assert.equal(proposalInfo[8], _proposalInfo[8]);
   //proposer;
-  assert.equal(proposalInfo[10], _proposalInfo[10]);
+  assert.equal(proposalInfo[9], _proposalInfo[9]);
   //boostedVotePeriodLimit;
+  assert.equal(proposalInfo[10], _proposalInfo[10]);
+  //paramsHash;
   assert.equal(proposalInfo[11], _proposalInfo[11]);
-  // - the mapping is simply not returned at all in the array
+  //daoBountyRemain;
+  assert.equal(proposalInfo[12], _proposalInfo[12]);
+  // - the mapping and array are simply not returned at all in the array
 };
 
 const checkVotesStatus = async function(proposalId, _votesStatus,genesisProtocol){
@@ -249,7 +251,21 @@ contract('GenesisProtocol', function (accounts) {
       assert.isOk(proposalId);
 
       var submittedTime = await  web3.eth.getBlock("latest").timestamp;
-      await checkProposalInfo(proposalId, [testSetup.org.avatar.address, numberOfChoices, testSetup.executable.address, 0,0,lostReputation,submittedTime,0,state,winningVote,accounts[0],60],testSetup.genesisProtocol);
+      await checkProposalInfo(proposalId, [
+                                          testSetup.org.avatar.address,
+                                          numberOfChoices,
+                                          testSetup.executable.address,
+                                          0,
+                                          lostReputation,
+                                          submittedTime,
+                                          0,
+                                          state,
+                                          winningVote,
+                                          accounts[0],
+                                          60,
+                                          testSetup.genesisProtocolParams.paramsHash,
+                                          0
+                                          ],testSetup.genesisProtocol);
       await checkVotesStatus(proposalId, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],testSetup.genesisProtocol);
       await checkIsVotable(proposalId, true,testSetup.genesisProtocol);
 
@@ -258,8 +274,24 @@ contract('GenesisProtocol', function (accounts) {
 
       winningVote = 1;
       lostReputation = (10 * testSetup.reputationArray[0])/100; //10 % of testSetup.reputationArray[0]
-
-      await checkProposalInfo(proposalId, [testSetup.org.avatar.address, numberOfChoices, testSetup.executable.address, testSetup.reputationArray[0], 0,lostReputation,submittedTime,0,state,winningVote,accounts[0],60],testSetup.genesisProtocol);
+      var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
+      assert.equal(testSetup.reputationArray[0],proposalStatus[0]);
+      assert.equal(testSetup.reputationArray[0],proposalStatus[1]);
+      await checkProposalInfo(proposalId, [
+                                           testSetup.org.avatar.address,
+                                           numberOfChoices,
+                                           testSetup.executable.address,
+                                           0,
+                                           lostReputation,
+                                           submittedTime,
+                                           0,
+                                           state,
+                                           winningVote,
+                                           accounts[0],
+                                           60,
+                                           testSetup.genesisProtocolParams.paramsHash,
+                                           0
+                                           ],testSetup.genesisProtocol);
       await checkVoteInfo(proposalId, accounts[0], [1, testSetup.reputationArray[0]],testSetup.genesisProtocol);
       await checkVotesStatus(proposalId, [0, testSetup.reputationArray[0],0],testSetup.genesisProtocol);
       await checkIsVotable(proposalId, true,testSetup.genesisProtocol);
@@ -267,7 +299,25 @@ contract('GenesisProtocol', function (accounts) {
       await testSetup.genesisProtocol.vote(proposalId, 2, { from: accounts[1] });
       await checkVoteInfo(proposalId, accounts[1], [2, testSetup.reputationArray[1]],testSetup.genesisProtocol);
       lostReputation += (10 * testSetup.reputationArray[1])/100;
-      await checkProposalInfo(proposalId, [testSetup.org.avatar.address, numberOfChoices, testSetup.executable.address, (testSetup.reputationArray[0] + testSetup.reputationArray[1]),0, lostReputation,submittedTime,0,state,winningVote,accounts[0],60],testSetup.genesisProtocol);
+      proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
+      assert.equal(testSetup.reputationArray[0] + testSetup.reputationArray[1],proposalStatus[0]);
+      assert.equal(testSetup.reputationArray[0] + testSetup.reputationArray[1],proposalStatus[1]);
+
+      await checkProposalInfo(proposalId,[
+                                           testSetup.org.avatar.address,
+                                           numberOfChoices,
+                                           testSetup.executable.address,
+                                           0,
+                                          lostReputation,
+                                          submittedTime,
+                                          0,
+                                          state,
+                                          winningVote,
+                                          accounts[0],
+                                          60,
+                                          testSetup.genesisProtocolParams.paramsHash,
+                                          0
+                                          ],testSetup.genesisProtocol);
 
       await checkVotesStatus(proposalId, [0,testSetup.reputationArray[0], testSetup.reputationArray[1]],testSetup.genesisProtocol);
       await checkIsVotable(proposalId, true,testSetup.genesisProtocol);
@@ -713,7 +763,20 @@ contract('GenesisProtocol', function (accounts) {
     var submittedTime = await  web3.eth.getBlock("latest").timestamp;
     var state = 3;
     var winningVote = 2;
-    await checkProposalInfo(proposalId, [testSetup.org.avatar.address, 2, testSetup.executable.address, 0, 0,0,submittedTime,0,state,winningVote,accounts[0],60],testSetup.genesisProtocol);
+    await checkProposalInfo(proposalId, [testSetup.org.avatar.address,
+                                         2,
+                                        testSetup.executable.address,
+                                        0,
+                                        0,
+                                        submittedTime,
+                                        0,
+                                        state,
+                                        winningVote,
+                                        accounts[0],
+                                        60,
+                                        testSetup.genesisProtocolParams.paramsHash,
+                                        0
+                                         ],testSetup.genesisProtocol);
 
     // lets try to vote by the owner on the behalf of non-existent voters(they do exist but they aren't registered to the reputation system).
     for (var i = 3; i < accounts.length; i++) {
@@ -1003,7 +1066,7 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(staker[1],20);
 
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],18); //totalStakes -votersFee - in this case voterFee = 10%  so
+    assert.equal(proposalStatus[2],18); //totalStakes -votersFee - in this case voterFee = 10%  so
   });
 
   it("stake without approval - fail", async () => {
@@ -1047,8 +1110,8 @@ contract('GenesisProtocol', function (accounts) {
     assert.isOk(proposalId);
     //shift proposal to boosted phase
     var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[4],0);
-    assert.equal(proposalInfo[8],3);
+    assert.equal(proposalInfo[3],0);
+    assert.equal(proposalInfo[7],3);
     await testSetup.genesisProtocol.vote(proposalId,YES);
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),false);
@@ -1056,9 +1119,9 @@ contract('GenesisProtocol', function (accounts) {
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
 
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],90); //totalStakes
-    assert.equal(proposalInfo[4],10);  //voterStakes
-    assert.equal(proposalInfo[8],4);  //state boosted
+    assert.equal(proposalStatus[2],90); //totalStakes
+    assert.equal(proposalInfo[3],10);  //voterStakes
+    assert.equal(proposalInfo[7],4);  //state boosted
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     //S = (S+) - (S-)
@@ -1079,8 +1142,8 @@ contract('GenesisProtocol', function (accounts) {
     assert.isOk(proposalId);
     //shift proposal to boosted phase
     var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[4],0);
-    assert.equal(proposalInfo[8],3);
+    assert.equal(proposalInfo[3],0);
+    assert.equal(proposalInfo[7],3);
     await testSetup.genesisProtocol.vote(proposalId,YES);
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),false);
@@ -1088,9 +1151,9 @@ contract('GenesisProtocol', function (accounts) {
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
 
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],90); //totalStakes
-    assert.equal(proposalInfo[4],10);  //voterStakes
-    assert.equal(proposalInfo[8],4);   //state boosted
+    assert.equal(proposalStatus[2],90); //totalStakes
+    assert.equal(proposalInfo[3],10);  //voterStakes
+    assert.equal(proposalInfo[7],4);   //state boosted
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     //S* POW(R/totalR)
@@ -1120,10 +1183,10 @@ contract('GenesisProtocol', function (accounts) {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],90); //totalStakes
+    assert.equal(proposalStatus[2],90); //totalStakes
 
-    assert.equal(proposalInfo[4],10);  //voterStakes
-    assert.equal(proposalInfo[8],4);   //state boosted
+    assert.equal(proposalInfo[3],10);  //voterStakes
+    assert.equal(proposalInfo[7],4);   //state boosted
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     var score = 100;
@@ -1148,10 +1211,10 @@ contract('GenesisProtocol', function (accounts) {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],90); //totalStakes
+    assert.equal(proposalStatus[2],90); //totalStakes
 
-    assert.equal(proposalInfo[4],10);  //voterStakes
-    assert.equal(proposalInfo[8],4);   //state boosted
+    assert.equal(proposalInfo[3],10);  //voterStakes
+    assert.equal(proposalInfo[7],4);   //state boosted
 
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     var score = 100;
@@ -1174,10 +1237,10 @@ contract('GenesisProtocol', function (accounts) {
     await stake(testSetup,proposalId,YES,100,accounts[0]);
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
     let proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[1],90); //totalStakes
+    assert.equal(proposalStatus[2],90); //totalStakes
 
-    assert.equal(proposalInfo[4],10);  //voterStakes
-    assert.equal(proposalInfo[8],4);   //state
+    assert.equal(proposalInfo[3],10);  //voterStakes
+    assert.equal(proposalInfo[7],4);   //state
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
   });
 
@@ -1223,21 +1286,24 @@ contract('GenesisProtocol', function (accounts) {
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     await helpers.increaseTime(61);
     await testSetup.genesisProtocol.execute(proposalId);
-    var stakerRedeemAmount = await testSetup.genesisProtocol.getRedeemableTokensStaker(proposalId,accounts[0]);
-    assert.equal(stakerRedeemAmount,90);
-    var voterRedeemAmount = await testSetup.genesisProtocol.getRedeemableTokensVoter(proposalId,accounts[0]);
-    assert.equal(voterRedeemAmount,10);
+    // var stakerRedeemAmount = await testSetup.genesisProtocol.getRedeemableTokensStaker(proposalId,accounts[0]);
+    // assert.equal(stakerRedeemAmount,90);
+    // var voterRedeemAmount = await testSetup.genesisProtocol.getRedeemableTokensVoter(proposalId,accounts[0]);
+    // assert.equal(voterRedeemAmount,10);
+    var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,accounts[0]);
+    var redeemToken = redeemRewards[0];
+    assert.equal(redeemToken,10+90);
     assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
     var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[2],100);
+    assert.equal(proposalStatus[3],100);
     tx = await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
     proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
-    assert.equal(proposalStatus[2],0);
+    assert.equal(proposalStatus[3],0);
     assert.equal(tx.logs.length,2);
     assert.equal(tx.logs[0].event, "Redeem");
     assert.equal(tx.logs[0].args._proposalId, proposalId);
     assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
-    assert.equal(tx.logs[0].args._amount, voterRedeemAmount.toNumber()+stakerRedeemAmount.toNumber());
+    assert.equal(tx.logs[0].args._amount, redeemToken.toNumber());
     assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),1000);
   });
 
@@ -1325,36 +1391,23 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
-      var redeemAmount = await testSetup.genesisProtocol.getRedeemableTokensStaker(proposalId,accounts[0]);
-      assert.equal(redeemAmount,90);
-      assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
-
-      //20% of the lost reputation
-      var rep4Stake = await testSetup.genesisProtocol.getRedeemableReputationStaker(proposalId,accounts[0]);
-      assert.equal(rep4Stake,1);
-      //80% of the lost reputation + the votersReputationLossRatio.
-      var rep4Vote = await testSetup.genesisProtocol.getRedeemableReputationVoter(proposalId,accounts[0]);
-      assert.equal(rep4Vote,3);
-      var rep4Propose = await testSetup.genesisProtocol.getRedeemableReputationProposer(proposalId);
-      //(params.proposingRepRewardConstA.mul(proposal.totalVotes) + params.proposingRepRewardConstB.mul(proposal.votes[YES]-proposal.votes[NO]))/1000;
-      assert.equal(rep4Propose,((60000*20)+ 1000*(20-0))/1000);
+      var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,accounts[0]);
+      var redeemToken = redeemRewards[0];
+      var RedeemReputation = redeemRewards[1];
+      assert.equal(redeemToken,100);
       tx = await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
       assert.equal(tx.logs.length, 2);
       assert.equal(tx.logs[0].event, "Redeem");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
       assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
       assert.equal(tx.logs[0].args._amount, 100);
-      //getRedeemableReputationProposer should return 0 after redeeming
-      assert.equal(await testSetup.genesisProtocol.getRedeemableReputationProposer(proposalId),0);
       assert.equal(tx.logs[1].event, "RedeemReputation");
       assert.equal(tx.logs[1].args._proposalId, proposalId);
       assert.equal(tx.logs[1].args._beneficiary, accounts[0]);
-      var totalRep =  rep4Stake.toNumber() + rep4Vote.toNumber() + rep4Propose.toNumber();
-      assert.equal(tx.logs[1].args._amount, totalRep);
-
+      assert.equal(tx.logs[1].args._amount, RedeemReputation.toNumber());
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),1000);
       var loss = (10*testSetup.reputationArray[0])/100;  //votersReputationLossRatio
-      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + totalRep - loss);
+      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + RedeemReputation.toNumber() - loss);
     });
 
     it("reputation flow for unsuccessful voting", async () => {
@@ -1367,28 +1420,18 @@ contract('GenesisProtocol', function (accounts) {
 
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
-      var redeemAmount = await testSetup.genesisProtocol.getRedeemableTokensStaker(proposalId , accounts[0]);
-      assert.equal(redeemAmount,0);
-
-      //20% of the lost reputation
-      var rep4Stake = await testSetup.genesisProtocol.getRedeemableReputationStaker(proposalId,accounts[0]);
-      assert.equal(rep4Stake,0);
-      // the votersReputationLossRatio.
-      var rep4Vote = await testSetup.genesisProtocol.getRedeemableReputationVoter(proposalId,accounts[0]);
-      assert.equal(rep4Vote,2);
-      var rep4Propose = await testSetup.genesisProtocol.getRedeemableReputationProposer(proposalId);
-      //for unsuccessful proposal it should be 0
-      assert.equal(rep4Propose,0);
+      var redeemRewards = await testSetup.genesisProtocol.redeem.call(proposalId,accounts[0]);
+      var totalRep = redeemRewards[1];
       tx = await testSetup.genesisProtocol.redeem(proposalId,accounts[0]);
       assert.equal(tx.logs.length, 1);
       assert.equal(tx.logs[0].event, "RedeemReputation");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
       assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
-      var totalRep =  rep4Stake.toNumber() + rep4Vote.toNumber() + rep4Propose.toNumber();
-      assert.equal(tx.logs[0].args._amount, totalRep);
+      //var totalRep =  rep4Stake.toNumber() + rep4Vote.toNumber() + rep4Propose.toNumber();
+      assert.equal(tx.logs[0].args._amount, totalRep.toNumber());
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),1000);
       var loss = (10*testSetup.reputationArray[0])/100;  //votersReputationLossRatio
-      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + totalRep - loss);
+      assert.equal(await testSetup.org.reputation.reputationOf(accounts[0]),testSetup.reputationArray[0] + totalRep.toNumber() - loss);
     });
 
     it("quite window ", async () => {
@@ -1404,7 +1447,7 @@ contract('GenesisProtocol', function (accounts) {
       await stake(testSetup,proposalId,YES,100,accounts[0]);
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],4);//boosted
+      assert.equal(proposalInfo[7],4);//boosted
 
       await helpers.increaseTime(50); //get into the quite period
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),2);
@@ -1413,13 +1456,13 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),2);
 
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],5);//quietEndingPeriod -still not execute
+      assert.equal(proposalInfo[7],5);//quietEndingPeriod -still not execute
       await helpers.increaseTime(15); //increase time
 
       await testSetup.genesisProtocol.execute(proposalId);
 
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],5);//boosted -still not execute
+      assert.equal(proposalInfo[7],5);//boosted -still not execute
       await helpers.increaseTime(10); //increase time
       assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
 
@@ -1432,7 +1475,7 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],2);//executed
+      assert.equal(proposalInfo[7],2);//executed
     });
 
     it("quite window with tie ", async () => {
@@ -1449,11 +1492,11 @@ contract('GenesisProtocol', function (accounts) {
       await helpers.increaseTime(15); //increase time
       await testSetup.genesisProtocol.execute(proposalId);
       var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],5);//boosted -still not execute
+      assert.equal(proposalInfo[7],5);//boosted -still not execute
       await helpers.increaseTime(10); //increase time
       await testSetup.genesisProtocol.execute(proposalId);
       proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-      assert.equal(proposalInfo[8],2);//executed
+      assert.equal(proposalInfo[7],2);//executed
       assert.equal(await testSetup.genesisProtocol.winningVote(proposalId),NO);
     });
 
@@ -1495,22 +1538,20 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
       await helpers.increaseTime(61);
       await testSetup.genesisProtocol.execute(proposalId);
-      var stakerRedeemAmountBaunty = await testSetup.genesisProtocol.getRedeemableTokensStakerBounty(proposalId,accounts[0]);
-      assert.equal(stakerRedeemAmountBaunty,10);
-        try {
-          await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
-          assert(false, 'there is no tokens on the dao for bounty');
-        } catch (ex) {
-          helpers.assertVMException(ex);
-        }
+      var redeemRewards = await testSetup.genesisProtocol.redeemDaoBounty.call(proposalId,accounts[0]);
+      var stakerRedeemAmountBaunty = redeemRewards[0];
+      var potentialAmount = redeemRewards[1];
+      assert.equal(potentialAmount,10);
+      //'there is no tokens on the dao for bounty'
+      assert.equal(stakerRedeemAmountBaunty,0);
       //send tokens to org avatar
-      await testSetup.stakingToken.transfer(testSetup.org.avatar.address,stakerRedeemAmountBaunty);
+      await testSetup.stakingToken.transfer(testSetup.org.avatar.address,potentialAmount);
       tx = await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event, "RedeemDaoBounty");
       assert.equal(tx.logs[0].args._proposalId, proposalId);
       assert.equal(tx.logs[0].args._beneficiary, accounts[0]);
-      assert.equal(tx.logs[0].args._amount, stakerRedeemAmountBaunty.toNumber());
+      assert.equal(tx.logs[0].args._amount, potentialAmount.toNumber());
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
 
     });
@@ -1524,7 +1565,8 @@ contract('GenesisProtocol', function (accounts) {
 
       await stake(testSetup,proposalId,2,100,accounts[0]);
       await testSetup.genesisProtocol.vote(proposalId,NO,{from:accounts[2]});
-      var stakerRedeemAmountBaunty = await testSetup.genesisProtocol.getRedeemableTokensStakerBounty(proposalId,accounts[0]);
+      var redeemRewards = await testSetup.genesisProtocol.redeemDaoBounty.call(proposalId,accounts[0]);
+      var stakerRedeemAmountBaunty = redeemRewards[0];
       assert.equal(stakerRedeemAmountBaunty,0);
       //send tokens to org avatar
       tx = await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
@@ -1544,11 +1586,11 @@ contract('GenesisProtocol', function (accounts) {
     await stake(testSetup,proposalId,1,100,accounts[0]);
     assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
     var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[8],4);//boosted
+    assert.equal(proposalInfo[7],4);//boosted
     //vote YES to get in quite window period
     await testSetup.genesisProtocol.vote(proposalId,1,{from:accounts[0]}); //change winning vote
     proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
-    assert.equal(proposalInfo[8],5);//quiteEndperiod
+    assert.equal(proposalInfo[7],5);//quiteEndperiod
     await helpers.increaseTime(10); //increase time
     assert.equal(await testSetup.genesisProtocol.orgBoostedProposalsCnt(testSetup.org.avatar.address),1);
     //vote NO to toggle direction again and extend the quite end period
@@ -1558,6 +1600,59 @@ contract('GenesisProtocol', function (accounts) {
     await helpers.increaseTime(61); //increase time
     assert.equal(await testSetup.genesisProtocol.threshold(testSetup.genesisProtocolParams.paramsHash,testSetup.org.avatar.address),1);
 
+  });
+
+  it("pre boosted voters are rewarded from staker", async () => {
+    var proposer = accounts[2];
+    var staker   = accounts[1];
+    var voter    = accounts[0];
+
+    var testSetup = await setup(accounts,50,60,60,1,1,0,0,60,1,10,10,0,15,10);
+    await testSetup.stakingToken.transfer(staker,500,{from:accounts[0]});
+
+    let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,proposer);
+    var proposalId = await getValueFromLogs(tx, '_proposalId');
+    assert.isOk(proposalId);
+    await testSetup.genesisProtocol.vote(proposalId,1,{from:voter});
+    //boost proposal
+    await stake(testSetup,proposalId,1,100,staker);
+    assert.equal(await testSetup.genesisProtocol.shouldBoost(proposalId),true);
+    var proposalInfo = await testSetup.genesisProtocol.proposals(proposalId);
+    assert.equal(proposalInfo[7],4);//boosted
+    await helpers.increaseTime(100); //increase time to execute
+    await testSetup.genesisProtocol.execute(proposalId); //execute
+    var redeemValues = await testSetup.genesisProtocol.redeem.call(proposalId,voter);
+    var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
+    var votersStakes = proposalStatus[4];
+    var preBoostedVotes = proposalStatus[1];
+    assert.equal(preBoostedVotes,testSetup.reputationArray[0]);
+    assert.equal(redeemValues[0].toNumber(),votersStakes.toNumber()*testSetup.reputationArray[0]/preBoostedVotes.toNumber());
+    assert.equal(redeemValues[0].toNumber(),10);
+  });
+
+  it("boosted voters are not rewarded from staker", async () => {
+    var proposer = accounts[2];
+    var staker   = accounts[1];
+    var voter    = accounts[0];
+
+    var testSetup = await setup(accounts,50,60,60,1,1,0,0,60,1,10,10,0,15,10);
+    await testSetup.stakingToken.transfer(staker,500,{from:accounts[0]});
+
+    let tx = await testSetup.genesisProtocol.propose(2, 0, testSetup.org.avatar.address, testSetup.executable.address,proposer);
+    var proposalId = await getValueFromLogs(tx, '_proposalId');
+    assert.isOk(proposalId);
+    //boost proposal
+    await stake(testSetup,proposalId,1,100,staker);
+    await testSetup.genesisProtocol.vote(proposalId,1,{from:voter});
+    await helpers.increaseTime(100); //increase time to execute
+    await testSetup.genesisProtocol.execute(proposalId); //execute
+    var redeemValues = await testSetup.genesisProtocol.redeem.call(proposalId,voter);
+    var proposalStatus = await testSetup.genesisProtocol.proposalStatus(proposalId);
+    var votersStakes = proposalStatus[4];
+    assert.equal(votersStakes,10);
+    var preBoostedVotes = proposalStatus[1];
+    assert.equal(preBoostedVotes,0);
+    assert.equal(redeemValues[0].toNumber(),0);
   });
 
 


### PR DESCRIPTION
- redeem function returns amount and reputation.
   In order to get the potential redeem rewards for a specific beneficiary client should call redeem with 'call' ( the contract state does not changed).
`e.g 'genesisProtocol.redeem.call(proposalId,beneficiary);'`
- redeemDaoBounty function return amount and potentialAmount for the case there is not enough token on the avatar.
- Redeemer.redeem gives back all rewards amount
.`e.g 'redeemer.redeem.call(proposalId,beneficiary);'`
  In order to get the potential redeem dao bounty rewards for a specific beneficiary client should call redeemDaoBounty  with 'call' ( the contract state does not changed) and get the potential reward.
- public getters functions for specific rewards are removed. 
- This update save around 200000 gas (on deployment).
- Update - stakerFee is now divided only between  pre boosted voters.
- Reputation flow is only for pre boosting voters.
- lostReputation is calculate from only from only from voters who votes right.
- add getBoostedProposalsCounts func
- change proposalStatus return values