### PR TITLE
bug fix : zero beneficiary daobounty only if actual redeeming was done.

### DIFF
--- a/contracts/VotingMachines/GenesisProtocol.sol
+++ b/contracts/VotingMachines/GenesisProtocol.sol
@@ -524,11 +524,11 @@ contract GenesisProtocol is IntVoteInterface,UniversalScheme {
             if (potentialAmount > beneficiaryLimit) {
                 potentialAmount = beneficiaryLimit;
             }
-            proposal.stakers[_beneficiary].amountForBounty = 0;
         }
         if ((potentialAmount != 0)&&(stakingToken.balanceOf(proposal.avatar) >= potentialAmount)) {
             proposal.daoBountyRemain = proposal.daoBountyRemain.sub(potentialAmount);
             require(ControllerInterface(Avatar(proposal.avatar).owner()).externalTokenTransfer(stakingToken,_beneficiary,potentialAmount,proposal.avatar));
+            proposal.stakers[_beneficiary].amountForBounty = 0;
             redeemedAmount = potentialAmount;
             emit RedeemDaoBounty(_proposalId,proposal.avatar,_beneficiary,redeemedAmount);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.0-alpha.49",
+  "version": "0.0.0-alpha.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.0-alpha.49",
+  "version": "0.0.0-alpha.50",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1545,6 +1545,8 @@ contract('GenesisProtocol', function (accounts) {
       //'there is no tokens on the dao for bounty'
       assert.equal(stakerRedeemAmountBaunty,0);
       //send tokens to org avatar
+      tx = await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
+      assert.equal(tx.logs.length,0); //not enough funds 
       await testSetup.stakingToken.transfer(testSetup.org.avatar.address,potentialAmount);
       tx = await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
       assert.equal(tx.logs.length,1);

--- a/test/genesisprotocol.js
+++ b/test/genesisprotocol.js
@@ -1554,6 +1554,9 @@ contract('GenesisProtocol', function (accounts) {
       assert.equal(tx.logs[0].args._amount, potentialAmount.toNumber());
       assert.equal(await testSetup.stakingToken.balanceOf(accounts[0]),900);
 
+      tx = await testSetup.genesisProtocol.redeemDaoBounty(proposalId,accounts[0]);
+      assert.equal(tx.logs.length,0);
+
     });
 
     it("redeem dao bounty for unsuccessful proposal", async () => {


### PR DESCRIPTION
This bug was introduced at on latest release 0.0.0-alpha.49
