### PR TITLE
DaoCreator -add addFounders function

### DIFF
--- a/contracts/universalSchemes/DaoCreator.sol
+++ b/contracts/universalSchemes/DaoCreator.sol
@@ -38,6 +38,40 @@ contract DaoCreator {
         controllerCreator = _controllerCreator;
     }
 
+    /**
+      * @dev addFounders add founders to the organization.
+      *      this function can be called only after forgeOrg and before setSchemes
+      * @param _avatar the organization avatar
+      * @param _founders An array with the addresses of the founders of the organization
+      * @param _foundersTokenAmount An array of amount of tokens that the founders
+      *  receive in the new organization
+      * @param _foundersReputationAmount An array of amount of reputation that the
+      *   founders receive in the new organization
+      * @return bool true or false
+      */
+    function addFounders (
+        Avatar _avatar,
+        address[] _founders,
+        uint[] _foundersTokenAmount,
+        uint[] _foundersReputationAmount
+      )
+      external
+      returns(bool)
+      {
+        require(_founders.length == _foundersTokenAmount.length);
+        require(_founders.length == _foundersReputationAmount.length);
+        require(_founders.length > 0);
+        require(locks[address(_avatar)] == msg.sender);
+        // Mint token and reputation for founders:
+        for (uint i = 0 ; i < _founders.length ; i++ ) {
+            require(_founders[i] != address(0));
+            ControllerInterface(_avatar.owner()).mintTokens(_foundersTokenAmount[i],_founders[i],address(_avatar));
+            ControllerInterface(_avatar.owner()).mintReputation(_foundersReputationAmount[i],_founders[i],address(_avatar));
+        }
+        return true;
+
+    }
+
   /**
     * @dev Create a new organization
     * @param _orgName The name of the new organization

--- a/contracts/universalSchemes/DaoCreator.sol
+++ b/contracts/universalSchemes/DaoCreator.sol
@@ -65,8 +65,12 @@ contract DaoCreator {
         // Mint token and reputation for founders:
         for (uint i = 0 ; i < _founders.length ; i++ ) {
             require(_founders[i] != address(0));
-            ControllerInterface(_avatar.owner()).mintTokens(_foundersTokenAmount[i],_founders[i],address(_avatar));
-            ControllerInterface(_avatar.owner()).mintReputation(_foundersReputationAmount[i],_founders[i],address(_avatar));
+            if (_foundersTokenAmount[i] > 0) {
+                ControllerInterface(_avatar.owner()).mintTokens(_foundersTokenAmount[i],_founders[i],address(_avatar));
+            }
+            if (_foundersReputationAmount[i] > 0) {
+                ControllerInterface(_avatar.owner()).mintReputation(_foundersReputationAmount[i],_founders[i],address(_avatar));
+            }
         }
         return true;
 
@@ -180,8 +184,12 @@ contract DaoCreator {
         // Mint token and reputation for founders:
         for (uint i = 0 ; i < _founders.length ; i++ ) {
             require(_founders[i] != address(0));
-            nativeToken.mint(_founders[i],_foundersTokenAmount[i]);
-            nativeReputation.mint(_founders[i],_foundersReputationAmount[i]);
+            if (_foundersTokenAmount[i] > 0) {
+                nativeToken.mint(_founders[i],_foundersTokenAmount[i]);
+            }
+            if (_foundersReputationAmount[i] > 0) {
+                nativeReputation.mint(_founders[i],_foundersReputationAmount[i]);
+            }
         }
 
         // Create Controller:

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -333,8 +333,7 @@ contract('DaoCreator', function(accounts) {
               helpers.assertVMException(ex);
             }
 
-        var tx = await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{gas:constants.ARC_GAS_LIMIT});
-        console.log(tx);
+        await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{gas:constants.ARC_GAS_LIMIT});
         var rep = await reputation.reputationOf(accounts[1]);
         assert.equal(rep.toNumber(),numberOfFounders);
         var founderBalance = await token.balanceOf(accounts[1]);

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -318,7 +318,8 @@ contract('DaoCreator', function(accounts) {
         var founderReputation = [];
         var founderToken = [];
         var i;
-        for (i=0;i<60;i++) {
+        var numberOfFounders = 60;
+        for (i=0;i<numberOfFounders;i++) {
           foundersArray[i] = accounts[1];
           founderReputation[i] = 1;
           founderToken[i] = 1;
@@ -332,11 +333,12 @@ contract('DaoCreator', function(accounts) {
               helpers.assertVMException(ex);
             }
 
-        await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{gas:constants.ARC_GAS_LIMIT});
+        var tx = await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{gas:constants.ARC_GAS_LIMIT});
+        console.log(tx);
         var rep = await reputation.reputationOf(accounts[1]);
-        assert.equal(rep.toNumber(),60);
+        assert.equal(rep.toNumber(),numberOfFounders);
         var founderBalance = await token.balanceOf(accounts[1]);
-        assert.equal(founderBalance.toNumber(),60);
+        assert.equal(founderBalance.toNumber(),numberOfFounders);
         var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -311,5 +311,36 @@ contract('DaoCreator', function(accounts) {
          helpers.assertVMException(ex);
        }
    });
+    it("setSchemes to none UniversalScheme and addFounders", async function() {
+        var amountToMint = 10;
+        await setup(accounts,amountToMint,amountToMint);
+        var foundersArray = [];
+        var founderReputation = [];
+        var founderToken = [];
+        var i;
+        for (i=0;i<60;i++) {
+          foundersArray[i] = accounts[1];
+          founderReputation[i] = 1;
+          founderToken[i] = 1;
+
+        }
+        try {
+              await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{from:accounts[1],gas:constants.ARC_GAS_LIMIT});
+              assert(false,"should revert  because account is lock for account 0");
+            }
+            catch(ex){
+              helpers.assertVMException(ex);
+            }
+
+        await daoCreator.addFounders(avatar.address,foundersArray,founderReputation,founderToken,{gas:constants.ARC_GAS_LIMIT});
+        var rep = await reputation.reputationOf(accounts[1]);
+        assert.equal(rep.toNumber(),60);
+        var founderBalance = await token.balanceOf(accounts[1]);
+        assert.equal(founderBalance.toNumber(),60);
+        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "InitialSchemesSet");
+        assert.equal(tx.logs[0].args._avatar, avatar.address);
+      });
 
 });


### PR DESCRIPTION
Currently forgeOrg with 60 founders consume about 7539885 gas 
This function will extend the capability of DaoCreator to forgeOrg with any number of founders in the cost of additional transactions .
Each call to addFounders can be used to add up to 120 founders in the cost of 650000 gas.

So to create a dao : 
1. `forgeOrg` - with up to 60 founders
2. `addFounders` -optional calls with up to 120 founders each call
3.  `setSchemes` - to finalise the dao creation. 
