### PR TITLE
Truffle v5

### DIFF
--- a/contracts/universalSchemes/ContributionReward.sol
+++ b/contracts/universalSchemes/ContributionReward.sol
@@ -348,6 +348,7 @@ contract ContributionReward is UniversalScheme,GenesisProtocolCallbacks,GenesisP
     * @return  periods left to be paid.
     */
     function getPeriodsToPay(bytes32 _proposalId, address _avatar,uint _redeemType) public view returns (uint) {
+        require(_redeemType <= 3,"should be in the redeemedPeriods range");
         ContributionProposal memory _proposal = organizationsProposals[_avatar][_proposalId];
         if (_proposal.executionTime == 0)
             return 0;

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -16,17 +16,20 @@ var ControllerCreator = artifacts.require('./ControllerCreator.sol');
 const orgName = "TEST_ORGANIZATION";
 const tokenName = "TestToken";
 const tokenSymbol = "TST";
-const founders = [web3.eth.accounts[0]];
-const initRep = 10;
-const initRepInWei = [web3.toWei(initRep)];
-const initToken = 1000;
-const initTokenInWei = [web3.toWei(initToken)];
-const cap = web3.toWei(100000000);
+const founders = [];
+const initRep = web3.utils.toWei("10");
+const initRepInWei = [initRep];
+const initToken = web3.utils.toWei("1000");
+const initTokenInWei = [initToken];
+const cap = web3.utils.toWei("100000000","ether");
+
 
 
 // DAOstack parameters for universal schemes:
 
 const votePrec = 50;
+
+var accounts;
 
 //Deploy test organization with the following schemes:
 //schemeRegistrar, upgradeScheme,globalConstraintRegistrar,simpleICO,contributionReward.
@@ -34,14 +37,17 @@ module.exports = async function(deployer) {
     deployer.deploy(ControllerCreator, {gas: constants.ARC_GAS_LIMIT}).then(async function(){
       var controllerCreator = await ControllerCreator.deployed();
       await deployer.deploy(DaoCreator,controllerCreator.address);
-      var daoCreatorInst = await DaoCreator.deployed(controllerCreator.address);
+      var daoCreatorInst = await DaoCreator.deployed(controllerCreator.address,{gas: constants.ARC_GAS_LIMIT});
       // Create DAOstack:
+
+      await web3.eth.getAccounts(function(err,res) { accounts = res; });
+      founders[0] = accounts[0];
       var returnedParams = await daoCreatorInst.forgeOrg(orgName, tokenName, tokenSymbol, founders,
           initTokenInWei, initRepInWei,0,cap,{gas: constants.ARC_GAS_LIMIT});
       var AvatarInst = await Avatar.at(returnedParams.logs[0].args._avatar);
       var ControllerInst = await Controller.at(await AvatarInst.owner());
       var reputationAddress = await ControllerInst.nativeReputation();
-      await deployer.deploy(AbsoluteVote);
+      await deployer.deploy(AbsoluteVote,{gas: constants.ARC_GAS_LIMIT});
       // Deploy AbsoluteVote:
       var AbsoluteVoteInst = await AbsoluteVote.deployed();
       // Deploy SchemeRegistrar:
@@ -65,13 +71,10 @@ module.exports = async function(deployer) {
 
       await schemeRegistrarInst.setParameters(voteParametersHash, voteParametersHash, AbsoluteVoteInst.address);
       var schemeRegisterParams = await schemeRegistrarInst.getParametersHash(voteParametersHash, voteParametersHash, AbsoluteVoteInst.address);
-
-      await globalConstraintRegistrarInst.setParameters(reputationAddress, votePrec);
-      var schemeGCRegisterParams = await globalConstraintRegistrarInst.getParametersHash(reputationAddress, votePrec);
-
+      await globalConstraintRegistrarInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
+      var schemeGCRegisterParams = await globalConstraintRegistrarInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address);
       await upgradeSchemeInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
       var schemeUpgradeParams = await upgradeSchemeInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address);
-
 
       await simpleICOInst.setParameters(1000, 1, 1, 2, web3.eth.accounts[0], web3.eth.accounts[0]);
       var simpleICOParams = await simpleICOInst.getParametersHash(1000, 1, 1, 2, web3.eth.accounts[0], web3.eth.accounts[0]);

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -1,7 +1,6 @@
 //this migration file is used only for testing purpose
 var constants = require('../test/constants');
 var Avatar = artifacts.require('./Avatar.sol');
-var Controller = artifacts.require('./Controller.sol');
 var UController = artifacts.require('./UController.sol');
 var DaoCreator = artifacts.require('./DaoCreator.sol');
 var GlobalConstraintRegistrar = artifacts.require('./GlobalConstraintRegistrar.sol');
@@ -45,8 +44,6 @@ module.exports = async function(deployer) {
       var returnedParams = await daoCreatorInst.forgeOrg(orgName, tokenName, tokenSymbol, founders,
           initTokenInWei, initRepInWei,0,cap,{gas: constants.ARC_GAS_LIMIT});
       var AvatarInst = await Avatar.at(returnedParams.logs[0].args._avatar);
-      var ControllerInst = await Controller.at(await AvatarInst.owner());
-      var reputationAddress = await ControllerInst.nativeReputation();
       await deployer.deploy(AbsoluteVote,{gas: constants.ARC_GAS_LIMIT});
       // Deploy AbsoluteVote:
       var AbsoluteVoteInst = await AbsoluteVote.deployed();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,7 +1273,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3042,6 +3043,7 @@
       "version": "6.1.8",
       "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.1.8.tgz",
       "integrity": "sha512-yXzteu4SIgUL31mnpm9j+x6dpHUw0p/nsRVkcySKq0w+1vDxH9jMErP1QhZAJuTVE6ni4nfvGSNkaQx5cD3jfg==",
+      "dev": true,
       "requires": {
         "source-map-support": "^0.5.3"
       }
@@ -6133,7 +6135,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -6152,6 +6155,7 @@
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,12 +1695,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypto-js": {
-      "version": "3.1.9-1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=",
-      "dev": true
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2269,31 +2263,6 @@
         "keccakjs": "^0.2.0",
         "rlp": "^2.0.0",
         "secp256k1": "^3.0.1"
-      }
-    },
-    "ethjs-abi": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.1.8.tgz",
-      "integrity": "sha1-zSiFg+1ijN+tr4re+juh28vKbBg=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        },
-        "js-sha3": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
-          "dev": true
-        }
       }
     },
     "eventemitter2": {
@@ -3569,12 +3538,6 @@
         "is-extglob": "^1.0.0"
       }
     },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -4288,24 +4251,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "number-to-bn": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
-      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6330,15 +6275,6 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "dev": true,
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -6483,62 +6419,15 @@
       "dev": true
     },
     "truffle": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
-      "integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+      "version": "5.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.0-beta.0.tgz",
+      "integrity": "sha512-hZ3TvO0ByHZabVvF5kH3phliAMLbeTM9XrBuJRTfM5x2Q4kHVYnTQa1oOhetPPVPaULsVai5T+iQPV3ptOq9jA==",
       "dev": true,
       "requires": {
         "mocha": "^4.1.0",
         "original-require": "1.0.1",
         "solc": "0.4.24"
       }
-    },
-    "truffle-blockchain-utils": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz",
-      "integrity": "sha1-pOXAZNrdafeCoTfz0nbSEJXaekc=",
-      "dev": true
-    },
-    "truffle-contract": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/truffle-contract/-/truffle-contract-3.0.6.tgz",
-      "integrity": "sha1-Lvb8Mtf6r6n0rtjlAAGp/eo0IZI=",
-      "dev": true,
-      "requires": {
-        "ethjs-abi": "0.1.8",
-        "truffle-blockchain-utils": "^0.0.5",
-        "truffle-contract-schema": "^2.0.1",
-        "truffle-error": "^0.0.3",
-        "web3": "0.20.6"
-      }
-    },
-    "truffle-contract-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/truffle-contract-schema/-/truffle-contract-schema-2.0.1.tgz",
-      "integrity": "sha1-m/gh0y4m5nS6FetdQPlrELHJ1Wg=",
-      "dev": true,
-      "requires": {
-        "ajv": "^5.1.1",
-        "crypto-js": "^3.1.9-1",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "truffle-error": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/truffle-error/-/truffle-error-0.0.3.tgz",
-      "integrity": "sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=",
-      "dev": true
     },
     "tv4": {
       "version": "1.3.0",
@@ -6745,12 +6634,6 @@
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
-    "utf8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
-      "dev": true
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6836,30 +6719,6 @@
         "uuid": "^3.0.1"
       }
     },
-    "web3": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
-      "integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
-      "dev": true,
-      "requires": {
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2": "*",
-        "xmlhttprequest": "*"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-        },
-        "crypto-js": {
-          "version": "3.1.8",
-          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
-          "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU=",
-          "dev": true
-        }
-      }
-    },
     "when": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
@@ -6935,18 +6794,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
-      "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "solc": "^0.4.24",
     "solc-cli": "^0.3.0",
     "solium": "^1.1.8",
-    "truffle": "^4.1.11",
-    "truffle-contract": "^3.0.5",
+    "truffle": "beta",
     "uint32": "^0.2.1"
   },
   "repository": {
@@ -84,7 +83,7 @@
   "dependencies": {
     "@daostack/infra": "^0.0.0-alpha.05",
     "ethereumjs-abi": "^0.6.5",
-    "ganache-cli": "^6.1.6",
+    "ganache-cli": "^6.1.8",
     "openzeppelin-solidity": "1.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
   "dependencies": {
     "@daostack/infra": "^0.0.0-alpha.05",
     "ethereumjs-abi": "^0.6.5",
-    "ganache-cli": "^6.1.8",
     "openzeppelin-solidity": "1.12.0"
+  },
+  "peerDependencies": {
+    "ganache-cli": "^6.1.8"
   }
 }

--- a/test/controller.js
+++ b/test/controller.js
@@ -3,19 +3,17 @@ const Controller = artifacts.require("./Controller.sol");
 const Reputation = artifacts.require("./Reputation.sol");
 const Avatar = artifacts.require("./Avatar.sol");
 const DAOToken   = artifacts.require("./DAOToken.sol");
-const StandardTokenMock = artifacts.require('./StandardTokenMock.sol');
 const GlobalConstraintMock = artifacts.require('./test/GlobalConstraintMock.sol');
 const ActionMock = artifacts.require('./test/ActionMock.sol');
-const UniversalSchemeMock = artifacts.require('./test/UniversalSchemeMock.sol');
+const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 var constants = require('../test/constants');
 
 
 var uint32 = require('uint32');
-let accounts = web3.eth.accounts;
 let reputation, avatar,token,controller;
 var amountToMint = 10;
 
-const setup = async function (permission='0',registerScheme = accounts[0]) {
+const setup = async function (accounts,permission='0',registerScheme = accounts[0]) {
   var _controller;
   token  = await DAOToken.new("TEST","TST",0);
   // set up a reputation system
@@ -24,11 +22,13 @@ const setup = async function (permission='0',registerScheme = accounts[0]) {
   avatar = await Avatar.new('name', token.address, reputation.address);
   if (permission !== '0') {
     _controller = await Controller.new(avatar.address,{from:accounts[1],gas: constants.ARC_GAS_LIMIT});
-    await _controller.registerScheme(registerScheme,0,permission,avatar.address,{from:accounts[1]});
+    await _controller.registerScheme(registerScheme,"0x0000000000000000000000000000000000000000",permission,avatar.address,{from:accounts[1]});
     await _controller.unregisterSelf(avatar.address,{from:accounts[1]});
   }
   else {
+
     _controller = await Controller.new(avatar.address,{gas: constants.ARC_GAS_LIMIT});
+
   }
   controller = _controller;
   return _controller;
@@ -37,27 +37,26 @@ const setup = async function (permission='0',registerScheme = accounts[0]) {
 const constraint = async function (method, pre=false, post=false) {
   var globalConstraints = await GlobalConstraintMock.new();
   let globalConstraintsCountOrig = await controller.globalConstraintsCount(avatar.address);
-  await globalConstraints.setConstraint(method,pre,post);
-  await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
+  await globalConstraints.setConstraint(web3.utils.asciiToHex(method),pre,post);
+  await controller.addGlobalConstraint(globalConstraints.address,web3.utils.asciiToHex("0"),avatar.address);
   let globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
   assert.equal(globalConstraintsCount[0].toNumber(),globalConstraintsCountOrig[0].toNumber() + (pre ? 0 : 1));
   assert.equal(globalConstraintsCount[1].toNumber(),globalConstraintsCountOrig[1].toNumber() + (post ? 0 : 1));
   return globalConstraints;
 };
 
-contract('Controller', function (accounts)  {
+contract('Controller', accounts =>  {
 
-     it("getGlobalConstraintParameters", async function() {
-          controller = await setup();
+     it("getGlobalConstraintParameters", async() => {
+          controller = await setup(accounts);
           // separate cases for pre and post
           var globalConstraints = await constraint("gcParams1", true);
           await controller.addGlobalConstraint(globalConstraints.address,"0x1235",avatar.address);
-
           var paramsHash = await controller.getGlobalConstraintParameters(globalConstraints.address, avatar.address);
 
           assert.equal(paramsHash,"0x1235000000000000000000000000000000000000000000000000000000000000");
-
           globalConstraints = await constraint("gcParams2", false, true);
+
           await controller.addGlobalConstraint(globalConstraints.address,"0x1236",avatar.address);
 
           paramsHash = await controller.getGlobalConstraintParameters(globalConstraints.address, avatar.address);
@@ -66,7 +65,7 @@ contract('Controller', function (accounts)  {
       });
 
       it("mint reputation via controller", async () => {
-          controller = await setup();
+          controller = await setup(accounts);
           await reputation.transferOwnership(controller.address);
           let tx =  await controller.mintReputation(amountToMint,accounts[0],avatar.address);
           assert.equal(tx.logs.length, 1);
@@ -78,7 +77,7 @@ contract('Controller', function (accounts)  {
       });
 
     it("burn reputation via controller", async () => {
-        controller = await setup();
+        controller = await setup(accounts);
         await reputation.transferOwnership(controller.address);
         await controller.mintReputation(amountToMint,accounts[0],avatar.address);
         let tx =  await controller.burnReputation(amountToMint-1,accounts[0],avatar.address);
@@ -91,7 +90,7 @@ contract('Controller', function (accounts)  {
     });
 
     it("mint tokens via controller", async () => {
-        controller = await setup();
+        controller = await setup(accounts);
         await token.transferOwnership(controller.address);
         let tx =  await controller.mintTokens(amountToMint,accounts[0],avatar.address);
         assert.equal(tx.logs.length, 1);
@@ -102,8 +101,8 @@ contract('Controller', function (accounts)  {
     });
 
     it("register schemes", async () => {
-        controller = await setup();
-        let tx =  await controller.registerScheme(accounts[1], 0,0,avatar.address);
+        controller = await setup(accounts);
+        let tx =  await controller.registerScheme(accounts[1], web3.utils.asciiToHex("0"),"0x00000000",avatar.address);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "RegisterScheme");
     });
@@ -135,15 +134,15 @@ contract('Controller', function (accounts)  {
 
     it("register schemes - check permissions for updating existing scheme", async () => {
       // Check scheme has at least the permissions it is changing, and at least the current permissions.
-      controller = await setup('0x0000000F');
+      controller = await setup(accounts,'0x0000000F');
        // scheme with permission 0x0000000F should be able to register scheme with permission 0x00000001
-        let tx = await controller.registerScheme(accounts[0],0,'0x'+uint32.toHex(1),avatar.address);
+        let tx = await controller.registerScheme(accounts[0],"0x0000000000000000000000000000000000000000","0x00000001",avatar.address);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "RegisterScheme");
 
-        controller = await setup('0x00000001');
+        controller = await setup(accounts,'0x00000001');
         try {
-          await controller.registerScheme(accounts[0],0,'0x'+uint32.toHex(2),avatar.address);
+          await controller.registerScheme(accounts[0],"0x0000000000000000000000000000000000000000","0x00000002",avatar.address);
           assert(false, 'scheme with permission 0x00000001 should not be able to register scheme with permission 0x00000002');
         } catch (ex) {
           helpers.assertVMException(ex);
@@ -151,13 +150,13 @@ contract('Controller', function (accounts)  {
     });
 
     it("unregister schemes", async () => {
-        controller = await setup();
+        controller = await setup(accounts);
         let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "UnregisterScheme");
     });
     it("unregister none registered scheme", async () => {
-        controller = await setup();
+        controller = await setup(accounts);
         let tx =  await controller.unregisterScheme(accounts[1],avatar.address);
         assert.equal(tx.logs.length, 0);
     });
@@ -165,7 +164,7 @@ contract('Controller', function (accounts)  {
     it("unregister schemes - check permissions unregister scheme", async () => {
       // Check scheme has at least the permissions it is changing, and at least the current permissions.
       //1. setup
-      controller = await setup();
+      controller = await setup(accounts);
       //2. account[0] register schemes ,on account[1] with variables permissions which could unregister other schemes.
       var i,j;
       var tx;
@@ -173,11 +172,11 @@ contract('Controller', function (accounts)  {
       var unregisteredScheme = accounts[2];
       for(i = 0; i <= 15; i++ ){
         //registered scheme has already permission to register(2)
-        tx = await controller.registerScheme(registeredScheme,0,'0x'+uint32.toHex(i|3),avatar.address);
+        tx = await controller.registerScheme(registeredScheme,"0x0000000000000000000000000000000000000000",'0x'+uint32.toHex(i|3),avatar.address);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "RegisterScheme");
         for(j = 0; j <= 15; j++ ){
-          tx = await controller.registerScheme(unregisteredScheme,0,'0x'+uint32.toHex(j),avatar.address);
+          tx = await controller.registerScheme(unregisteredScheme,"0x0000000000000000000000000000000000000000",'0x'+uint32.toHex(j),avatar.address);
           assert.equal(tx.logs.length, 1);
           assert.equal(tx.logs[0].event, "RegisterScheme");
           //try to unregisterScheme
@@ -200,10 +199,10 @@ contract('Controller', function (accounts)  {
      });
 
      it("call with none valid avatar should revert", async () => {
-       controller = await setup();
+       controller = await setup(accounts);
        var registeredScheme = accounts[1];
        try {
-           await controller.registerScheme(registeredScheme,0,'0x'+uint32.toHex(1|3),0);
+           await controller.registerScheme(registeredScheme,"0x0000000000000000000000000000000000000000",'0x'+uint32.toHex(1|3),"0x0000000000000000000000000000000000000000");
            assert(false, "call with none valid avatar should revert");
          } catch (ex) {
              helpers.assertVMException(ex);
@@ -212,7 +211,7 @@ contract('Controller', function (accounts)  {
 
      it("unregister self", async () => {
        var tx;
-       controller = await setup("0x00000000");
+       controller = await setup(accounts,"0x00000000");
        tx = await controller.unregisterSelf(avatar.address,{ from: accounts[1]});
        assert.equal(tx.logs.length, 0); // scheme was not registered
 
@@ -223,7 +222,7 @@ contract('Controller', function (accounts)  {
 
       it("isSchemeRegistered ", async () => {
         var isSchemeRegistered;
-        controller = await setup("0x00000000");
+        controller = await setup(accounts,"0x00000000");
         isSchemeRegistered = await controller.isSchemeRegistered(accounts[1],avatar.address);
         assert.equal(isSchemeRegistered, false);
         isSchemeRegistered = await controller.isSchemeRegistered(accounts[0],avatar.address);
@@ -231,9 +230,9 @@ contract('Controller', function (accounts)  {
        });
 
       it("addGlobalConstraint ", async () => {
-        controller = await setup();
-        var globalConstraints = await constraint("0");
-        var tx = await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
+        controller = await setup(accounts);
+        var globalConstraints = await constraint(0);
+        var tx = await controller.addGlobalConstraint(globalConstraints.address,"0x0000000000000000000000000000000000000000",avatar.address);
         assert.equal(await controller.isGlobalConstraintRegistered(globalConstraints.address,avatar.address),true);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "AddGlobalConstraint");
@@ -242,24 +241,25 @@ contract('Controller', function (accounts)  {
         assert.equal(count[1], 1); //post
        });
        it("removeGlobalConstraint ", async () => {
-         controller = await setup();
+         const zeroBytes32 = "0x0000000000000000000000000000000000000000";
+         controller = await setup(accounts);
          var globalConstraints = await GlobalConstraintMock.new();
-         await globalConstraints.setConstraint("0",false,false);
+         await globalConstraints.setConstraint(zeroBytes32,false,false);
          var globalConstraints1 = await GlobalConstraintMock.new();
-         await globalConstraints1.setConstraint("method",false,false);
+         await globalConstraints1.setConstraint(web3.utils.asciiToHex("method"),false,false);
          var globalConstraints2 = await GlobalConstraintMock.new();
-         await globalConstraints2.setConstraint("method",false,false);
+         await globalConstraints2.setConstraint(web3.utils.asciiToHex("method"),false,false);
          var globalConstraints3 = await GlobalConstraintMock.new();
-         await globalConstraints3.setConstraint("method",false,false);
+         await globalConstraints3.setConstraint(web3.utils.asciiToHex("method"),false,false);
          var globalConstraints4 = await GlobalConstraintMock.new();
-         await globalConstraints4.setConstraint("method",false,false);
+         await globalConstraints4.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
          assert.equal(await controller.isGlobalConstraintRegistered(globalConstraints.address,avatar.address),false);
-         await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
-         await controller.addGlobalConstraint(globalConstraints1.address,0,avatar.address);
-         await controller.addGlobalConstraint(globalConstraints2.address,0,avatar.address);
-         await controller.addGlobalConstraint(globalConstraints3.address,0,avatar.address);
-         await controller.addGlobalConstraint(globalConstraints4.address,0,avatar.address);
+         await controller.addGlobalConstraint(globalConstraints.address,zeroBytes32,avatar.address);
+         await controller.addGlobalConstraint(globalConstraints1.address,zeroBytes32,avatar.address);
+         await controller.addGlobalConstraint(globalConstraints2.address,zeroBytes32,avatar.address);
+         await controller.addGlobalConstraint(globalConstraints3.address,zeroBytes32,avatar.address);
+         await controller.addGlobalConstraint(globalConstraints4.address,zeroBytes32,avatar.address);
          var tx = await controller.removeGlobalConstraint(globalConstraints2.address,avatar.address);
          assert.equal(tx.logs.length, 1);
          assert.equal(tx.logs[0].event, "RemoveGlobalConstraint");
@@ -282,7 +282,7 @@ contract('Controller', function (accounts)  {
         });
 
         it("upgrade controller ", async () => {
-          controller = await setup();
+          controller = await setup(accounts);
           await reputation.transferOwnership(controller.address);
           await token.transferOwnership(controller.address);
           await avatar.transferOwnership(controller.address);
@@ -292,7 +292,7 @@ contract('Controller', function (accounts)  {
         });
 
         it("upgrade controller check permission", async () => {
-          controller = await setup('0x00000007');
+          controller = await setup(accounts,'0x00000007');
           await reputation.transferOwnership(controller.address);
           await token.transferOwnership(controller.address);
           await avatar.transferOwnership(controller.address);
@@ -305,173 +305,170 @@ contract('Controller', function (accounts)  {
         });
 
         it("generic call log", async () => {
-          controller = await setup('0x00000010');
+          controller = await setup(accounts,'0x00000010');
           await avatar.transferOwnership(controller.address);
           let actionMock =  await ActionMock.new();
           let a = 7;
           let b = actionMock.address;
-          let c = 0x1234;
-          const extraData = await actionMock.test.request(a,b,c);
-          var tx = await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-          var log = await new Promise((resolve) => {
-                      avatar.GenericCall({fromBlock: tx.blockNumber})
-                          .get((err,events) => {
-                                  resolve(events);
-                          });
-                      });
-          assert.equal(log[0].args._contract,actionMock.address);
+          let c = "0x1234";
+          const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+          var tx = await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+          await avatar.getPastEvents('GenericCall', {
+                fromBlock: tx.blockNumber,
+                toBlock: 'latest'
+            })
+            .then(function(events){
+                assert.equal(events[0].event,"GenericCall");
+                assert.equal(events[0].args._contract,actionMock.address);
+            });
 
         });
 
         it("generic call", async () => {
-          controller = await setup('0x00000010');
+          controller = await setup(accounts,'0x00000010');
           await avatar.transferOwnership(controller.address);
           let actionMock =  await ActionMock.new();
           let a = 7;
           let b = actionMock.address;
-          let c = 0x1234;
-          const extraData = await actionMock.test.request(a,b,c);
-          var result = await controller.genericCall.call(actionMock.address,extraData.params[0].data,avatar.address);
+          let c = "0x1234";
+          const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+          var result = await controller.genericCall.call(actionMock.address,encodeABI,avatar.address);
           assert.equal(result, 14);
         });
 
         it("generic call withoutReturnValue", async () => {
-          controller = await setup('0x00000010');
+          controller = await setup(accounts,'0x00000010');
           await avatar.transferOwnership(controller.address);
           let actionMock =  await ActionMock.new();
-          const extraData = await actionMock.withoutReturnValue.request(avatar.address);
-          var tx = await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-          const log = await new Promise((resolve) => {
-                      actionMock.WithoutReturnValue({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                          .get((err,events) => {
-                                  resolve(events);
-                          });
-                      });
-          assert.equal(log[0].event,"WithoutReturnValue");
-        });
 
-        it("generic call via contract scheme", async () => {
-          var scheme = await UniversalSchemeMock.new();
-          controller = await setup('0x00000010',scheme.address);
-          await avatar.transferOwnership(controller.address);
-          let actionMock =  await ActionMock.new();
-          let a = 7;
-          let b = actionMock.address;
-          let c = 0x1234;
-          let result = await scheme.genericCall.call(avatar.address,actionMock.address, a,b,c);
-          assert.equal(result, 14);
-
+          const actionMockContract = await new web3.eth.Contract(actionMock.abi);
+          const encodeABI = actionMockContract.methods.withoutReturnValue(avatar.address).encodeABI();
+          var tx = await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+          await actionMock.getPastEvents('WithoutReturnValue', {
+                filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+                fromBlock: tx.blockNumber,
+                toBlock: 'latest'
+            })
+            .then(function(events){
+                assert.equal(events[0].event,"WithoutReturnValue");
+            });
         });
-
-        it("sendEther", async () => {
-          controller = await setup();
-          let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, avatar.address);
-          await avatar.transferOwnership(controller.address);
-          //send some ether to the avatar
-          web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.toWei('1', "ether")});
-          //send some ether from an organization's avatar to the otherAvatar
-          var tx = await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-          const log = await new Promise((resolve) => {
-                      avatar.SendEther({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                          .get((err,events) => {
-                                  resolve(events);
-                          });
-                      });
-          assert.equal(log[0].event,"SendEther");
-          var avatarBalance = web3.eth.getBalance(avatar.address)/web3.toWei('1', "ether");
-          assert.equal(avatarBalance, 0);
-          var otherAvatarBalance = web3.eth.getBalance(otherAvatar.address)/web3.toWei('1', "ether");
-          assert.equal(otherAvatarBalance, 1);
+    it("sendEther", async () => {
+      controller = await setup(accounts);
+      let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, avatar.address);
+      await avatar.transferOwnership(controller.address);
+      //send some ether to the avatar
+      await web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.utils.toWei('1', "ether")});
+      //send some ether from an organization's avatar to the otherAvatar
+      var tx = await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+      await avatar.getPastEvents('SendEther', {
+            filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+            fromBlock: tx.blockNumber,
+            toBlock: 'latest'
+        })
+        .then(function(events){
+            assert.equal(events[0].event,"SendEther");
         });
+      var avatarBalance = await web3.eth.getBalance(avatar.address)/web3.utils.toWei('1', "ether");
+      assert.equal(avatarBalance, 0);
+      var otherAvatarBalance = await web3.eth.getBalance(otherAvatar.address)/web3.utils.toWei('1', "ether");
+      assert.equal(otherAvatarBalance, 1);
+    });
 
-        it("externalTokenTransfer", async () => {
-          //External transfer token from avatar contract to other address
-          controller = await setup();
-          var standardToken = await StandardTokenMock.new(avatar.address, 100);
-          let balanceAvatar = await standardToken.balanceOf(avatar.address);
-          assert.equal(balanceAvatar, 100);
-          await avatar.transferOwnership(controller.address);
-          var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-          const log = await new Promise((resolve) => {
-                      avatar.ExternalTokenTransfer({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                          .get((err,events) => {
-                                  resolve(events);
-                          });
-                      });
-          assert.equal(log[0].event,"ExternalTokenTransfer");
-          balanceAvatar = await standardToken.balanceOf(avatar.address);
-          assert.equal(balanceAvatar, 50);
-          let balance1 = await standardToken.balanceOf(accounts[1]);
-          assert.equal(balance1, 50);
+    it("externalTokenTransfer", async () => {
+      //External transfer token from avatar contract to other address
+      controller = await setup(accounts);
+      var standardToken = await StandardTokenMock.new(avatar.address, 100);
+      let balanceAvatar = await standardToken.balanceOf(avatar.address);
+      assert.equal(balanceAvatar, 100);
+      await avatar.transferOwnership(controller.address);
+      var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
+      await avatar.getPastEvents('ExternalTokenTransfer', {
+            filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+            fromBlock: tx.blockNumber,
+            toBlock: 'latest'
+        })
+        .then(function(events){
+            assert.equal(events[0].event,"ExternalTokenTransfer");
         });
+      balanceAvatar = await standardToken.balanceOf(avatar.address);
+      assert.equal(balanceAvatar, 50);
+      let balance1 = await standardToken.balanceOf(accounts[1]);
+      assert.equal(balance1, 50);
+    });
 
-        it("externalTokenTransferFrom & ExternalTokenIncreaseApproval", async () => {
-          var tx;
-          var to   = accounts[1];
-          controller = await setup();
-          var standardToken = await StandardTokenMock.new(avatar.address, 100);
-          await avatar.transferOwnership(controller.address);
-          tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-          var log = await new Promise((resolve) => {
-                      avatar.ExternalTokenIncreaseApproval({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                          .get((err,events) => {
-                                  resolve(events);
-                          });
-                      });
-          assert.equal(log[0].event,"ExternalTokenIncreaseApproval");
-          tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-          log = await new Promise((resolve) => {
-                     avatar.ExternalTokenTransferFrom({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                         .get((err,events) => {
-                                 resolve(events);
-                         });
-                     });
-         assert.equal(log[0].event,"ExternalTokenTransferFrom");
-          let balanceAvatar = await standardToken.balanceOf(avatar.address);
-          assert.equal(balanceAvatar, 50);
-          let balanceTo = await standardToken.balanceOf(to);
-          assert.equal(balanceTo, 50);
-        });
+    it("externalTokenTransferFrom & ExternalTokenIncreaseApproval", async () => {
+        var tx;
+        var to   = accounts[1];
+        controller = await setup(accounts);
+        var standardToken = await StandardTokenMock.new(avatar.address, 100);
+        await avatar.transferOwnership(controller.address);
+        tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+        await avatar.getPastEvents('ExternalTokenIncreaseApproval', {
+              filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+              fromBlock: tx.blockNumber,
+              toBlock: 'latest'
+          })
+          .then(function(events){
+              assert.equal(events[0].event,"ExternalTokenIncreaseApproval");
+          });
+        tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+        await avatar.getPastEvents('ExternalTokenTransferFrom', {
+              filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+              fromBlock: tx.blockNumber,
+              toBlock: 'latest'
+          })
+          .then(function(events){
+              assert.equal(events[0].event,"ExternalTokenTransferFrom");
+          });
+        let balanceAvatar = await standardToken.balanceOf(avatar.address);
+        assert.equal(balanceAvatar, 50);
+        let balanceTo = await standardToken.balanceOf(to);
+        assert.equal(balanceTo, 50);
+    });
 
-        it("externalTokenTransferFrom & externalTokenDecreaseApproval", async () => {
-          var tx;
-          var to   = accounts[1];
-          controller = await setup();
-          var standardToken = await StandardTokenMock.new(avatar.address, 100);
-          await avatar.transferOwnership(controller.address);
-          tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-          tx = await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-          var log = await new Promise((resolve) => {
-                     avatar.ExternalTokenDecreaseApproval({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                         .get((err,events) => {
-                                 resolve(events);
-                         });
-                     });
-         assert.equal(log[0].event,"ExternalTokenDecreaseApproval");
-          try{
-             await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-             assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
-            }
-            catch(ex){
-              helpers.assertVMException(ex);
-            }
-          tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-          tx=  await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-          log = await new Promise((resolve) => {
-                     avatar.ExternalTokenTransferFrom({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                         .get((err,events) => {
-                                 resolve(events);
-                         });
-                     });
-          assert.equal(log[0].event,"ExternalTokenTransferFrom");
-          let balanceAvatar = await standardToken.balanceOf(avatar.address);
-          assert.equal(balanceAvatar, 50);
-          let balanceTo = await standardToken.balanceOf(to);
-          assert.equal(balanceTo, 50);
+    it("externalTokenTransferFrom & externalTokenDecreaseApproval", async () => {
+      var tx;
+      var to   = accounts[1];
+      controller = await setup(accounts);
+      var standardToken = await StandardTokenMock.new(avatar.address, 100);
+      await avatar.transferOwnership(controller.address);
+      await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+      tx = await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+      await avatar.getPastEvents('ExternalTokenDecreaseApproval', {
+            filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+            fromBlock: tx.blockNumber,
+            toBlock: 'latest'
+        })
+        .then(function(events){
+            assert.equal(events[0].event,"ExternalTokenDecreaseApproval");
         });
+      try{
+         await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+         assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
+        }
+        catch(ex){
+          helpers.assertVMException(ex);
+        }
+      await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+      tx=  await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+      await avatar.getPastEvents('ExternalTokenTransferFrom', {
+            filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+            fromBlock: tx.blockNumber,
+            toBlock: 'latest'
+        })
+        .then(function(events){
+            assert.equal(events[0].event,"ExternalTokenTransferFrom");
+        });
+      let balanceAvatar = await standardToken.balanceOf(avatar.address);
+      assert.equal(balanceAvatar, 50);
+      let balanceTo = await standardToken.balanceOf(to);
+      assert.equal(balanceTo, 50);
+    });
+
 
     it("globalConstraints mintReputation add & remove", async () => {
-      await setup();
+      await setup(accounts);
       var globalConstraints = await constraint("mintReputation");
       await reputation.transferOwnership(controller.address);
       try {
@@ -493,56 +490,12 @@ contract('Controller', function (accounts)  {
       let rep = await reputation.reputationOf(accounts[0]);
       assert.equal(rep,amountToMint);
       });
-
-    it("globalConstraints mintTokens add & remove", async () => {
-
-      controller = await setup();
-      var globalConstraints = await constraint("mintTokens");
-      await token.transferOwnership(controller.address);
-      try {
-      await controller.mintTokens(amountToMint,accounts[0],avatar.address);
-      assert(false,"mint tokens should fail due to the global constraint ");
-      }
-      catch(ex){
-        helpers.assertVMException(ex);
-      }
-      await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-      var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-      assert.equal(globalConstraintsCount[0],0);
-      assert.equal(globalConstraintsCount[1],0);
-      let tx =  await controller.mintTokens(amountToMint,accounts[0],avatar.address);
-      assert.equal(tx.logs.length, 1);
-      assert.equal(tx.logs[0].event, "MintTokens");
-      assert.equal(tx.logs[0].args._amount, amountToMint);
-      let balance =  await token.balanceOf(accounts[0]);
-      assert.equal(balance,amountToMint);
-      });
-
-     it("globalConstraints register schemes add & remove", async () => {
-        controller = await setup();
-        var globalConstraints = await constraint("registerScheme");
-        try {
-        await controller.registerScheme(accounts[1], 0,0,avatar.address);
-        assert(false,"registerScheme should fail due to the global constraint ");
-        }
-        catch(ex){
-          helpers.assertVMException(ex);
-        }
-        await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-        var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-        assert.equal(globalConstraintsCount[0],0);
-        assert.equal(globalConstraintsCount[1],0);
-        let tx =  await controller.registerScheme(accounts[1], 0,0,avatar.address);
-        assert.equal(tx.logs.length, 1);
-        assert.equal(tx.logs[0].event, "RegisterScheme");
-        });
-
-    it("globalConstraints unregister schemes add & remove", async () => {
-       controller = await setup();
+      it("globalConstraints register schemes add & remove", async () => {
+       controller = await setup(accounts);
        var globalConstraints = await constraint("registerScheme");
        try {
-       await controller.unregisterScheme(accounts[0],avatar.address);
-       assert(false,"unregisterScheme should fail due to the global constraint ");
+       await controller.registerScheme(accounts[1], helpers.NULL_HASH,"0x00000000",avatar.address);
+       assert(false,"registerScheme should fail due to the global constraint ");
        }
        catch(ex){
          helpers.assertVMException(ex);
@@ -551,186 +504,207 @@ contract('Controller', function (accounts)  {
        var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
        assert.equal(globalConstraintsCount[0],0);
        assert.equal(globalConstraintsCount[1],0);
-       let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
+       let tx =  await controller.registerScheme(accounts[1], helpers.NULL_HASH,"0x00000000",avatar.address);
        assert.equal(tx.logs.length, 1);
-       assert.equal(tx.logs[0].event, "UnregisterScheme");
+       assert.equal(tx.logs[0].event, "RegisterScheme");
        });
 
- it("globalConstraints generic call  add & remove", async () => {
-    controller = await setup('0x00000014');
-    var globalConstraints = await constraint("genericCall");
-    await avatar.transferOwnership(controller.address);
-    let actionMock =  await ActionMock.new();
-    let a = 7;
-    let b = actionMock.address;
-    let c = 0x1234;
-    const extraData = await actionMock.test.request(a,b,c);
-    try {
-    await controller.genericCall.call(actionMock.address,extraData.params[0].data,avatar.address);
-    assert(false,"genericCall should fail due to the global constraint ");
-    }
-    catch(ex){
-      helpers.assertVMException(ex);
-    }
-    await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-    var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-    assert.equal(globalConstraintsCount[0],0);
-    assert.equal(globalConstraintsCount[1],0);
-    var tx =  await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-    var log = await new Promise((resolve) => {
-                avatar.GenericCall({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].args._contract,actionMock.address);
-    });
+    it("globalConstraints unregister schemes add & remove", async () => {
+      controller = await setup(accounts);
+      var globalConstraints = await constraint("registerScheme");
+      try {
+      await controller.unregisterScheme(accounts[0],avatar.address);
+      assert(false,"unregisterScheme should fail due to the global constraint ");
+      }
+      catch(ex){
+        helpers.assertVMException(ex);
+      }
+      await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+      var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+      assert.equal(globalConstraintsCount[0],0);
+      assert.equal(globalConstraintsCount[1],0);
+      let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "UnregisterScheme");
+      });
+      it("globalConstraints generic call  add & remove", async () => {
+         controller = await setup(accounts,'0x00000014');
+         var globalConstraints = await constraint("genericCall");
+         await avatar.transferOwnership(controller.address);
+         let actionMock =  await ActionMock.new();
+         let a = 7;
+         let b = actionMock.address;
+         let c = "0x1234";
+         const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+         try {
+         await controller.genericCall.call(actionMock.address,encodeABI,avatar.address);
+         assert(false,"genericCall should fail due to the global constraint ");
+         }
+         catch(ex){
+           helpers.assertVMException(ex);
+         }
+         await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+         var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+         assert.equal(globalConstraintsCount[0],0);
+         assert.equal(globalConstraintsCount[1],0);
+         var tx =  await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+         await avatar.getPastEvents('GenericCall', {
+               filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+               fromBlock: tx.blockNumber,
+               toBlock: 'latest'
+           })
+           .then(function(events){
+               assert.equal(events[0].event,"GenericCall");
+           });
+         });
 
     it("globalConstraints sendEther  add & remove", async () => {
-       controller = await setup();
-       var globalConstraints = await constraint("sendEther");
-       let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, avatar.address);
-       await avatar.transferOwnership(controller.address);
-       web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.toWei('1', "ether")});
+     controller = await setup(accounts);
+     var globalConstraints = await constraint("sendEther");
+     let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, avatar.address);
+     await avatar.transferOwnership(controller.address);
+     web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.utils.toWei('1', "ether")});
 
-       try {
-        await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-        assert(false,"sendEther should fail due to the global constraint ");
-       }
-       catch(ex){
-         helpers.assertVMException(ex);
-       }
-       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-       assert.equal(globalConstraintsCount[0],0);
-       var tx = await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-       var log = await new Promise((resolve) => {
-                   avatar.SendEther({fromBlock: tx.blockNumber})
-                       .get((err,events) => {
-                               resolve(events);
-                       });
-                   });
-       assert.equal(log[0].event,"SendEther");
-       var avatarBalance = web3.eth.getBalance(avatar.address)/web3.toWei('1', "ether");
-       assert.equal(avatarBalance, 0);
-       var otherAvatarBalance = web3.eth.getBalance(otherAvatar.address)/web3.toWei('1', "ether");
-       assert.equal(otherAvatarBalance, 1);
+     try {
+      await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+      assert(false,"sendEther should fail due to the global constraint ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+     await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+     var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+     assert.equal(globalConstraintsCount[0],0);
+     var tx = await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+     await avatar.getPastEvents('SendEther', {
+           filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+           fromBlock: tx.blockNumber,
+           toBlock: 'latest'
+       })
+       .then(function(events){
+           assert.equal(events[0].event,"SendEther");
        });
+     var avatarBalance = await web3.eth.getBalance(avatar.address)/web3.utils.toWei('1', "ether");
+     assert.equal(avatarBalance, 0);
+     var otherAvatarBalance = await web3.eth.getBalance(otherAvatar.address)/web3.utils.toWei('1', "ether");
+     assert.equal(otherAvatarBalance, 1);
+     });
 
-     it("globalConstraints externalTokenTransfer  add & remove", async () => {
-        controller = await setup();
-        var globalConstraints = await constraint("externalTokenTransfer");
-        var standardToken = await StandardTokenMock.new(avatar.address, 100);
-        let balanceAvatar = await standardToken.balanceOf(avatar.address);
-        assert.equal(balanceAvatar, 100);
-        await avatar.transferOwnership(controller.address);
+    it("globalConstraints externalTokenTransfer  add & remove", async () => {
+     controller = await setup(accounts);
+     var globalConstraints = await constraint("externalTokenTransfer");
+     var standardToken = await StandardTokenMock.new(avatar.address, 100);
+     let balanceAvatar = await standardToken.balanceOf(avatar.address);
+     assert.equal(balanceAvatar, 100);
+     await avatar.transferOwnership(controller.address);
 
-        try {
-         await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-         assert(false,"externalTokenTransfer should fail due to the global constraint ");
-        }
-        catch(ex){
-          helpers.assertVMException(ex);
-        }
-        await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-        var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-        assert.equal(globalConstraintsCount[0],0);
-        var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-        var log = await new Promise((resolve) => {
-                    avatar.ExternalTokenTransfer({fromBlock: tx.blockNumber})
-                        .get((err,events) => {
-                                resolve(events);
-                        });
-                    });
-        assert.equal(log[0].event,"ExternalTokenTransfer");
-
-        balanceAvatar = await standardToken.balanceOf(avatar.address);
-        assert.equal(balanceAvatar, 50);
-        let balance1 = await standardToken.balanceOf(accounts[1]);
-        assert.equal(balance1, 50);
-        });
-
-    it("globalConstraints externalTokenTransferFrom , externalTokenIncreaseApproval , externalTokenDecreaseApproval", async () => {
-       var tx;
-       var to   = accounts[1];
-       controller = await setup();
-       var globalConstraints = await constraint("externalTokenIncreaseApproval");
-       var standardToken = await StandardTokenMock.new(avatar.address, 100);
-       await avatar.transferOwnership(controller.address);
-
-       try {
-        await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-        assert(false,"externalTokenIncreaseApproval should fail due to the global constraint ");
-       }
-       catch(ex){
-         helpers.assertVMException(ex);
-       }
-       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-       assert.equal(globalConstraintsCount[0],0);
-
-       tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-
-       var log = await new Promise((resolve) => {
-                   avatar.ExternalTokenIncreaseApproval({fromBlock: tx.blockNumber})
-                       .get((err,events) => {
-                               resolve(events);
-                       });
-                   });
-       assert.equal(log[0].event,"ExternalTokenIncreaseApproval");
-
-       globalConstraints = await constraint("externalTokenTransferFrom");
-       try {
-        await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-        assert(false,"externalTokenTransferFrom should fail due to the global constraint ");
-       }
-       catch(ex){
-         helpers.assertVMException(ex);
-       }
-       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-       globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-       assert.equal(globalConstraintsCount[0],0);
-
-
-
-       globalConstraints = await constraint("externalTokenDecreaseApproval");
-       try {
-        await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-        assert(false,"externalTokenDecreaseApproval should fail due to the global constraint ");
-       }
-       catch(ex){
-         helpers.assertVMException(ex);
-       }
-       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-       await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-       try {
-        await await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-        assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
-       }
-       catch(ex){
-         helpers.assertVMException(ex);
-       }
-
-       await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-       tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-       log = await new Promise((resolve) => {
-                   avatar.ExternalTokenTransferFrom({fromBlock: tx.blockNumber})
-                       .get((err,events) => {
-                               resolve(events);
-                       });
-                   });
-       assert.equal(log[0].event,"ExternalTokenTransferFrom");
-       let balanceAvatar = await standardToken.balanceOf(avatar.address);
-       assert.equal(balanceAvatar, 50);
-       let balanceTo = await standardToken.balanceOf(to);
-       assert.equal(balanceTo, 50);
+     try {
+      await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
+      assert(false,"externalTokenTransfer should fail due to the global constraint ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+     await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+     var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+     assert.equal(globalConstraintsCount[0],0);
+     var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
+     await avatar.getPastEvents('ExternalTokenTransfer', {
+           filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+           fromBlock: tx.blockNumber,
+           toBlock: 'latest'
+       })
+       .then(function(events){
+           assert.equal(events[0].event,"ExternalTokenTransfer");
        });
+     balanceAvatar = await standardToken.balanceOf(avatar.address);
+     assert.equal(balanceAvatar, 50);
+     let balance1 = await standardToken.balanceOf(accounts[1]);
+     assert.equal(balance1, 50);
+     });
 
-    it("getNativeReputation", async () => {
 
-       controller = await setup();
-       var nativeReputation = await controller.getNativeReputation(avatar.address);
-       assert.equal(nativeReputation,reputation.address);
+     it("getNativeReputation", async () => {
 
-    });
+     controller = await setup(accounts);
+     var nativeReputation = await controller.getNativeReputation(avatar.address);
+     assert.equal(nativeReputation,reputation.address);
+
+     });
+
+     it("globalConstraints externalTokenTransferFrom , externalTokenIncreaseApproval , externalTokenDecreaseApproval", async () => {
+     var tx;
+     var to   = accounts[1];
+     controller = await setup(accounts);
+     var globalConstraints = await constraint("externalTokenIncreaseApproval");
+     var standardToken = await StandardTokenMock.new(avatar.address, 100);
+     await avatar.transferOwnership(controller.address);
+
+     try {
+      await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+      assert(false,"externalTokenIncreaseApproval should fail due to the global constraint ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+     await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+     var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+     assert.equal(globalConstraintsCount[0],0);
+
+     tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+     await avatar.getPastEvents('ExternalTokenIncreaseApproval', {
+           filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+           fromBlock: tx.blockNumber,
+           toBlock: 'latest'
+       })
+       .then(function(events){
+           assert.equal(events[0].event,"ExternalTokenIncreaseApproval");
+       });
+     globalConstraints = await constraint("externalTokenTransferFrom");
+     try {
+      await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+      assert(false,"externalTokenTransferFrom should fail due to the global constraint ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+     await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+     globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+     assert.equal(globalConstraintsCount[0],0);
+
+     globalConstraints = await constraint("externalTokenDecreaseApproval");
+     try {
+      await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+      assert(false,"externalTokenDecreaseApproval should fail due to the global constraint ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+     await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+     await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+     try {
+      await await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+      assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
+     }
+     catch(ex){
+       helpers.assertVMException(ex);
+     }
+
+     await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+     tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+     await avatar.getPastEvents('ExternalTokenTransferFrom', {
+           filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+           fromBlock: tx.blockNumber,
+           toBlock: 'latest'
+       })
+       .then(function(events){
+           assert.equal(events[0].event,"ExternalTokenTransferFrom");
+       });
+     let balanceAvatar = await standardToken.balanceOf(avatar.address);
+     assert.equal(balanceAvatar, 50);
+     let balanceTo = await standardToken.balanceOf(to);
+     assert.equal(balanceTo, 50);
+     });
+
+
 });

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -10,7 +10,7 @@ const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 const UniversalSchemeMock = artifacts.require('./test/UniversalSchemeMock.sol');
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 
-const zeroBytes32 = helpres.NULL_HASH;
+const zeroBytes32 = helpers.NULL_HASH;
 var avatar,token,reputation,daoCreator,uController,controllerCreator;
 const setup = async function (accounts,founderToken,founderReputation,useUController=false,cap=0) {
   controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -10,6 +10,7 @@ const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 const UniversalSchemeMock = artifacts.require('./test/UniversalSchemeMock.sol');
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 
+const zeroBytes32 = "0x0000000000000000000000000000000000000000";
 var avatar,token,reputation,daoCreator,uController,controllerCreator;
 const setup = async function (accounts,founderToken,founderReputation,useUController=false,cap=0) {
   controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
@@ -75,7 +76,7 @@ contract('DaoCreator', function(accounts) {
     it("setSchemes to none UniversalScheme", async function() {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint);
-        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");
         assert.equal(tx.logs[0].args._avatar, avatar.address);
@@ -85,7 +86,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint);
         var universalSchemeMock = await UniversalSchemeMock.new();
-        var tx = await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[0],["0x8000000F"]);
+        var tx = await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[zeroBytes32],["0x8000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");
         assert.equal(tx.logs[0].args._avatar, avatar.address);
@@ -95,7 +96,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint);
         try {
-         await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"],{ from: accounts[1]});
+         await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"],{ from: accounts[1]});
          assert(false,"should fail because accounts[1] does not hold the lock");
         }
         catch(ex){
@@ -110,7 +111,7 @@ contract('DaoCreator', function(accounts) {
         var universalSchemeMock = await UniversalSchemeMock.new();
         var allowance = await standardTokenMock.allowance(avatar.address,universalSchemeMock.address);
         assert.equal(allowance,0);
-        await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[0],["0x8000000F"]);
+        await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[zeroBytes32],["0x8000000F"]);
         allowance = await standardTokenMock.allowance(avatar.address,universalSchemeMock.address);
         assert.equal(allowance,0);
     });
@@ -122,7 +123,7 @@ contract('DaoCreator', function(accounts) {
         var allowance = await standardTokenMock.allowance(avatar.address,accounts[1]);
         assert.equal(allowance,0);
 
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         allowance = await standardTokenMock.allowance(avatar.address,accounts[1]);
         assert.equal(allowance,0);
     });
@@ -131,7 +132,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         var controllerAddress,controller;
         await setup(accounts,amountToMint,amountToMint);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         controllerAddress = await avatar.owner();
         controller = await Controller.at(controllerAddress);
         var isSchemeRegistered = await controller.isSchemeRegistered(accounts[1],avatar.address);
@@ -146,7 +147,7 @@ contract('DaoCreator', function(accounts) {
         controller = await Controller.at(controllerAddress);
         var isSchemeRegistered = await controller.isSchemeRegistered(daoCreator.address,avatar.address);
         assert.equal(isSchemeRegistered,true);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         controllerAddress = await avatar.owner();
         controller = await Controller.at(controllerAddress);
         isSchemeRegistered = await controller.isSchemeRegistered(daoCreator.address,avatar.address);
@@ -156,9 +157,9 @@ contract('DaoCreator', function(accounts) {
     it("setSchemes delete lock", async function() {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         try {
-         await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"],{ from: accounts[1]});
+         await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"],{ from: accounts[1]});
          assert(false,"should fail because lock for account[0] suppose to be deleted by the first call");
         }
         catch(ex){
@@ -193,7 +194,7 @@ contract('DaoCreator', function(accounts) {
     it("setSchemes with universal controller to none UniversalScheme", async function() {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint,true);
-        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");
         assert.equal(tx.logs[0].args._avatar, avatar.address);
@@ -203,7 +204,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint,true);
         var universalSchemeMock = await UniversalSchemeMock.new();
-        var tx = await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[0],["0x8000000F"]);
+        var tx = await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[zeroBytes32],["0x8000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");
         assert.equal(tx.logs[0].args._avatar, avatar.address);
@@ -213,7 +214,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint,true);
         try {
-         await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"],{ from: accounts[1]});
+         await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"],{ from: accounts[1]});
          assert(false,"should fail because accounts[1] does not hold the lock");
         }
         catch(ex){
@@ -228,7 +229,7 @@ contract('DaoCreator', function(accounts) {
         var universalSchemeMock = await UniversalSchemeMock.new();
         var allowance = await standardTokenMock.allowance(avatar.address,universalSchemeMock.address);
         assert.equal(allowance,0);
-        await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[0],["0x8000000F"]);
+        await daoCreator.setSchemes(avatar.address,[universalSchemeMock.address],[zeroBytes32],["0x8000000F"]);
         allowance = await standardTokenMock.allowance(avatar.address,universalSchemeMock.address);
         assert.equal(allowance,0);
         //check org registered in scheme
@@ -241,7 +242,7 @@ contract('DaoCreator', function(accounts) {
         var allowance = await standardTokenMock.allowance(avatar.address,accounts[1]);
         assert.equal(allowance,0);
 
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         allowance = await standardTokenMock.allowance(avatar.address,accounts[1]);
         assert.equal(allowance,0);
     });
@@ -250,7 +251,7 @@ contract('DaoCreator', function(accounts) {
         var amountToMint = 10;
         var controllerAddress,controller;
         await setup(accounts,amountToMint,amountToMint,true);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         controllerAddress = await avatar.owner();
         controller = await Controller.at(controllerAddress);
         var isSchemeRegistered = await controller.isSchemeRegistered(accounts[1],avatar.address);
@@ -265,7 +266,7 @@ contract('DaoCreator', function(accounts) {
         controller = await Controller.at(controllerAddress);
         var isSchemeRegistered = await controller.isSchemeRegistered(daoCreator.address,avatar.address);
         assert.equal(isSchemeRegistered,true);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         controllerAddress = await avatar.owner();
         controller = await Controller.at(controllerAddress);
         isSchemeRegistered = await controller.isSchemeRegistered(daoCreator.address,avatar.address);
@@ -275,9 +276,9 @@ contract('DaoCreator', function(accounts) {
     it("setSchemes with universal controller delete lock", async function() {
         var amountToMint = 10;
         await setup(accounts,amountToMint,amountToMint,true);
-        await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         try {
-         await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"],{ from: accounts[1]});
+         await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"],{ from: accounts[1]});
          assert(false,"should fail because lock for account[0] suppose to be deleted by the first call");
         }
         catch(ex){
@@ -333,7 +334,7 @@ contract('DaoCreator', function(accounts) {
         assert.equal(rep.toNumber(),numberOfFounders);
         var founderBalance = await token.balanceOf(accounts[1]);
         assert.equal(founderBalance.toNumber(),numberOfFounders);
-        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[0],["0x0000000F"]);
+        var tx = await daoCreator.setSchemes(avatar.address,[accounts[1]],[zeroBytes32],["0x0000000F"]);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "InitialSchemesSet");
         assert.equal(tx.logs[0].args._avatar, avatar.address);

--- a/test/daocreator.js
+++ b/test/daocreator.js
@@ -10,7 +10,7 @@ const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 const UniversalSchemeMock = artifacts.require('./test/UniversalSchemeMock.sol');
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 
-const zeroBytes32 = "0x0000000000000000000000000000000000000000";
+const zeroBytes32 = helpres.NULL_HASH;
 var avatar,token,reputation,daoCreator,uController,controllerCreator;
 const setup = async function (accounts,founderToken,founderReputation,useUController=false,cap=0) {
   controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});

--- a/test/daotoken.js
+++ b/test/daotoken.js
@@ -18,7 +18,7 @@ contract('DAOToken', accounts => {
     });
 
     it("should mint tokens to owner account", async () => {
-        helpers.etherForEveryone();
+        await helpers.etherForEveryone(accounts);
 
         let owner, totalSupply, userSupply;
         const token = await DAOToken.new(testTokenName,testTokenSymbol,0);
@@ -43,7 +43,7 @@ contract('DAOToken', accounts => {
     });
 
     it("should allow minting tokens only by owner", async () => {
-        helpers.etherForEveryone();
+        await helpers.etherForEveryone(accounts);
         const token = await DAOToken.new(testTokenName,testTokenSymbol,0);
         let owner = await token.owner();
         let totalSupply = await token.totalSupply();
@@ -58,7 +58,7 @@ contract('DAOToken', accounts => {
 
         // and so the supply of tokens should remain unchanged
         let newSupply = await token.totalSupply();
-        assert.equal(totalSupply.valueOf(), newSupply.valueOf());
+        assert.equal(totalSupply.toNumber(), newSupply.toNumber());
     });
 
     it("log the Mint event on mint", async () => {

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -5,13 +5,15 @@ const constants = require('./constants');
 var ExternalLocking4Reputation = artifacts.require("./ExternalLocking4Reputation.sol");
 var ExternalTokenLockerMock = artifacts.require("./ExternalTokenLockerMock.sol");
 
+
 const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   var block = await web3.eth.getBlock("latest");
+   testSetup.lockingEndTime = block.timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = block.timestamp + _lockingStartTime;
    testSetup.extetnalTokenLockerMock = await ExternalTokenLockerMock.new();
    await testSetup.extetnalTokenLockerMock.lock(100,{from:accounts[0]});
    await testSetup.extetnalTokenLockerMock.lock(200,{from:accounts[1]});
@@ -25,7 +27,7 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
                                                                       "lockedTokenBalances(address)");
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.externalLocking4Reputation.address],[0],[permissions]);
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.externalLocking4Reputation.address],[helpers.NULL_HASH],[permissions]);
    return testSetup;
 };
 

--- a/test/fixreputationallocation.js
+++ b/test/fixreputationallocation.js
@@ -14,7 +14,7 @@ const setup = async function (accounts,_repAllocation = 300) {
                                                                             _repAllocation);
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.fixedReputationAllocation.address],[0],[permissions]);
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.fixedReputationAllocation.address],[helpers.NULL_HASH],[permissions]);
    return testSetup;
 };
 

--- a/test/genesisprotocolcallbacks.js
+++ b/test/genesisprotocolcallbacks.js
@@ -5,7 +5,7 @@ const DaoCreator = artifacts.require("./DaoCreator.sol");
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 const ARCGenesisProtocolCallbacksMock = artifacts.require("./ARCGenesisProtocolCallbacksMock.sol");
 
-const proposalId = 0x1234000000000000000000000000000000000000000000000000000000000000;
+const proposalId = "0x1234000000000000000000000000000000000000000000000000000000000000";
 const setup = async function (accounts) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
@@ -18,7 +18,7 @@ const setup = async function (accounts) {
    var permissions = "0x00000000";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,
                                           [testSetup.arcGenesisProtocolCallbacksMock.address],
-                                          [0],
+                                          [helpers.NULL_HASH],
                                           [permissions]);
    await testSetup.arcGenesisProtocolCallbacksMock.propose(proposalId,
                                                            testSetup.org.avatar.address,

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -56,9 +56,9 @@ const setup = async function (accounts,genesisProtocol = false,tokenAddress=0) {
 
    return testSetup;
 };
-contract('GlobalConstraintRegistrar', function(accounts) {
+contract('GlobalConstraintRegistrar', accounts => {
 
-   it("setParameters", async function() {
+   it("setParameters", async ()=> {
      var globalConstraintRegistrar = await GlobalConstraintRegistrar.new();
      var params = await setupGlobalConstraintRegistrarParams(globalConstraintRegistrar);
      var parameters = await globalConstraintRegistrar.parameters(params.paramsHash);
@@ -110,8 +110,8 @@ contract('GlobalConstraintRegistrar', function(accounts) {
 
         var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                        globalConstraintMock.address,
-                                                                       0,
-                                                                       0);
+                                                                       "0x1234",
+                                                                       "0x1234");
         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
         await helpers.checkVoteInfo(testSetup.globalConstraintRegistrarParams.votingMachine.absoluteVote,proposalId,accounts[0],[1,testSetup.reputationArray[0]]);
        });
@@ -120,13 +120,13 @@ contract('GlobalConstraintRegistrar', function(accounts) {
          var testSetup = await setup(accounts);
          var controller = await Controller.at(await testSetup.org.avatar.owner());
          var globalConstraintMock = await GlobalConstraintMock.new();
-         await globalConstraintMock.setConstraint("method",false,false);
+         await globalConstraintMock.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
 
 
          var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                         globalConstraintMock.address,
-                                                                        0,
+                                                                        "0x1234",
                                                                         testSetup.globalConstraintRegistrarParams.votingMachine.params);
          assert.equal(tx.logs.length, 1);
          assert.equal(tx.logs[0].event, "NewGlobalConstraintsProposal");
@@ -142,11 +142,11 @@ contract('GlobalConstraintRegistrar', function(accounts) {
        it("proposeToRemoveGC log", async function() {
          var testSetup = await setup(accounts);
          var globalConstraintMock =await GlobalConstraintMock.new();
-         await globalConstraintMock.setConstraint("method",false,false);
+         await globalConstraintMock.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
          var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                         globalConstraintMock.address,
-                                                                        0,
+                                                                        "0x1234",
                                                                         testSetup.globalConstraintRegistrarParams.votingMachine.params);
          var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
          await testSetup.globalConstraintRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -173,11 +173,11 @@ contract('GlobalConstraintRegistrar', function(accounts) {
          it("proposeToRemoveGC check owner vote", async function() {
            var testSetup = await setup(accounts);
            var globalConstraintMock =await GlobalConstraintMock.new();
-           await globalConstraintMock.setConstraint("method",false,false);
+           await globalConstraintMock.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
            var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                           globalConstraintMock.address,
-                                                                          0,
+                                                                          "0x1234",
                                                                           testSetup.globalConstraintRegistrarParams.votingMachine.params);
            var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
            await testSetup.globalConstraintRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -192,11 +192,11 @@ contract('GlobalConstraintRegistrar', function(accounts) {
             var testSetup = await setup(accounts);
             var controller = await Controller.at(await testSetup.org.avatar.owner());
             var globalConstraintMock =await GlobalConstraintMock.new();
-            await globalConstraintMock.setConstraint("method",false,false);
+            await globalConstraintMock.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
             var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                            globalConstraintMock.address,
-                                                                           0,
+                                                                           "0x1234",
                                                                            testSetup.globalConstraintRegistrarParams.votingMachine.params);
             var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
             await testSetup.globalConstraintRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -217,11 +217,11 @@ contract('GlobalConstraintRegistrar', function(accounts) {
              var testSetup = await setup(accounts);
              var controller = await Controller.at(await testSetup.org.avatar.owner());
              var globalConstraintMock =await GlobalConstraintMock.new();
-             await globalConstraintMock.setConstraint("method",false,false);
+             await globalConstraintMock.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
              var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                             globalConstraintMock.address,
-                                                                            0,
+                                                                            "0x1234",
                                                                             testSetup.globalConstraintRegistrarParams.votingMachine.params);
              var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
              await testSetup.globalConstraintRegistrarParams.votingMachine.absoluteVote.vote(proposalId,0,0,{from:accounts[2]});
@@ -237,11 +237,11 @@ contract('GlobalConstraintRegistrar', function(accounts) {
           var testSetup = await setup(accounts,true,standardTokenMock.address);
           var globalConstraintMock =await GlobalConstraintMock.new();
           //genesisProtocol use burn reputation.
-          await globalConstraintMock.setConstraint("burnReputation",true,true);
+          await globalConstraintMock.setConstraint(web3.utils.asciiToHex("burnReputation"),true,true);
 
           var tx = await testSetup.globalConstraintRegistrar.proposeGlobalConstraint(testSetup.org.avatar.address,
                                                                          globalConstraintMock.address,
-                                                                         0,
+                                                                         "0x1234",
                                                                          testSetup.globalConstraintRegistrarParams.votingMachine.params);
 
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -86,11 +86,10 @@ export async function getProposal(tx) {
     return await Proposal.at(getProposalAddress(tx));
 }
 
-export async function etherForEveryone() {
+export async function etherForEveryone(accounts) {
     // give all web3.eth.accounts some ether
-    let accounts = web3.eth.accounts;
     for (let i=0; i < 10; i++) {
-        await web3.eth.sendTransaction({to: accounts[i], from: accounts[0], value: web3.toWei(0.1, "ether")});
+        await web3.eth.sendTransaction({to: accounts[i], from: accounts[0], value: web3.utils.toWei("0.1", "ether")});
     }
 }
 
@@ -224,9 +223,9 @@ export const checkVoteInfo = async function(absoluteVote,proposalId, voterAddres
   voteInfo = await absoluteVote.voteInfo(proposalId, voterAddress);
   // voteInfo has the following structure
   // int vote;
-  assert.equal(voteInfo[0], _voteInfo[0]);
+  assert.equal(voteInfo[0].toNumber(), _voteInfo[0]);
   // uint reputation;
-  assert.equal(voteInfo[1], _voteInfo[1]);
+  assert.equal(voteInfo[1].toNumber(), _voteInfo[1]);
 };
 
 
@@ -239,10 +238,28 @@ export const checkVotesStatus = async function(proposalId, _votesStatus,votingMa
   }
 };
 
-
+// export const increaseTime  = async function (addSeconds) {
+//     web3.currentProvider.sendAsync({
+//       jsonrpc: '2.0',
+//       method: 'evm_increaseTime',
+//       params: [addSeconds],
+//       id: new Date().getSeconds()
+//     }, (err) => {
+//       if (!err) {
+//         web3.currentProvider.send({
+//           jsonrpc: '2.0',
+//           method: 'evm_mine',
+//           params: [],
+//           id: new Date().getSeconds()
+//         });
+//       }
+//     });
+//   }
 // Increases testrpc time by the passed duration in seconds
 export const increaseTime = async function(duration) {
-  const id = Date.now();
+  const id = await Date.now();
+
+   web3.providers.HttpProvider.prototype.sendAsync = web3.providers.HttpProvider.prototype.send;
 
   return new Promise((resolve, reject) => {
     web3.currentProvider.sendAsync({

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -10,12 +10,12 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
    testSetup.lockingEth4Reputation = await LockingEth4Reputation.new(testSetup.org.avatar.address,_repAllocation,testSetup.lockingStartTime,testSetup.lockingEndTime,_maxLockingPeriod);
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingEth4Reputation.address],[0],[permissions]);
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingEth4Reputation.address],[helpers.NULL_HASH],[permissions]);
    return testSetup;
 };
 
@@ -29,12 +29,12 @@ contract('LockingEth4Reputation', accounts => {
 
     it("lock", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Lock");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._period,100);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
     });
@@ -42,7 +42,7 @@ contract('LockingEth4Reputation', accounts => {
     it("lock with value == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('0', "ether")});
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('0', "ether")});
         assert(false, "lock with value == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -52,7 +52,7 @@ contract('LockingEth4Reputation', accounts => {
     it("lock before start should revert", async () => {
       let testSetup = await setup(accounts,100,1000);
       try {
-        await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         assert(false, "lock before start should  revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -63,7 +63,7 @@ contract('LockingEth4Reputation', accounts => {
       let testSetup = await setup(accounts);
       await helpers.increaseTime(3001);
       try {
-        await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         assert(false, "lock after _lockingEndTime should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -73,7 +73,7 @@ contract('LockingEth4Reputation', accounts => {
     it("lock with period == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingEth4Reputation.lock(0,{value:web3.toWei('1', "ether")});
+        await testSetup.lockingEth4Reputation.lock(0,{value:web3.utils.toWei('1', "ether")});
         assert(false, "lock with period == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -83,7 +83,7 @@ contract('LockingEth4Reputation', accounts => {
     it("lock over _maxLockingPeriod should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingEth4Reputation.lock(6001,{value:web3.toWei('1', "ether")});
+        await testSetup.lockingEth4Reputation.lock(6001,{value:web3.utils.toWei('1', "ether")});
         assert(false, "lock over _maxLockingPeriod should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -92,20 +92,20 @@ contract('LockingEth4Reputation', accounts => {
 
     it("release", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       await helpers.increaseTime(101);
       tx = await testSetup.lockingEth4Reputation.release(accounts[0],lockingId);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Release");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._beneficiary,accounts[0]);
     });
 
     it("release before locking period should revert", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+      var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       try {
         await testSetup.lockingEth4Reputation.release(accounts[0],lockingId);
@@ -117,7 +117,7 @@ contract('LockingEth4Reputation', accounts => {
 
     it("release cannot release twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(101);
         await testSetup.lockingEth4Reputation.release(accounts[0],lockingId);
@@ -131,7 +131,7 @@ contract('LockingEth4Reputation', accounts => {
 
     it("redeem", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         tx = await testSetup.lockingEth4Reputation.redeem(accounts[0],lockingId);
@@ -145,9 +145,9 @@ contract('LockingEth4Reputation', accounts => {
 
     it("redeem score ", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingEth4Reputation.lock(100,{from:accounts[0],value:web3.toWei('1', "ether")});
+        var tx = await testSetup.lockingEth4Reputation.lock(100,{from:accounts[0],value:web3.utils.toWei('1', "ether")});
         var lockingId1 = await helpers.getValueFromLogs(tx, '_lockingId',1);
-        tx = await testSetup.lockingEth4Reputation.lock(300,{from:accounts[1],value:web3.toWei('1', "ether")});
+        tx = await testSetup.lockingEth4Reputation.lock(300,{from:accounts[1],value:web3.utils.toWei('1', "ether")});
         var lockingId2 = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingEth4Reputation.redeem(accounts[0],lockingId1);
@@ -158,7 +158,7 @@ contract('LockingEth4Reputation', accounts => {
 
     it("redeem cannot redeem twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingEth4Reputation.redeem(accounts[0],lockingId);
@@ -172,7 +172,7 @@ contract('LockingEth4Reputation', accounts => {
 
     it("redeem before lockingEndTime should revert", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        var tx = await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(50);
         try {

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -7,12 +7,12 @@ var LockingToken4Reputation = artifacts.require("./LockingToken4Reputation.sol")
 
 const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_maxLockingPeriod = 6000) {
    var testSetup = new helpers.TestSetup();
-   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.toWei('100', "ether"));
+   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.utils.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
    testSetup.lockingToken4Reputation = await LockingToken4Reputation.new(testSetup.org.avatar.address,
                                                                        _repAllocation,
                                                                       testSetup.lockingStartTime,
@@ -21,8 +21,8 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
                                                                       testSetup.lockingToken.address);
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[0],[permissions]);
-   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"));
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[helpers.NULL_HASH],[permissions]);
+   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"));
    return testSetup;
 };
 
@@ -37,12 +37,12 @@ contract('LockingToken4Reputation', accounts => {
 
     it("lock", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Lock");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._period,100);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
     });
@@ -50,7 +50,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock with value == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('0', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('0', "ether"),100);
         assert(false, "lock with value == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -61,7 +61,7 @@ contract('LockingToken4Reputation', accounts => {
       let testSetup = await setup(accounts);
       await helpers.increaseTime(3001);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         assert(false, "lock after _lockingEndTime should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -71,7 +71,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock before start should  revert", async () => {
       let testSetup = await setup(accounts,100,100);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
         assert(false, "lock before start should  revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -81,7 +81,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock with period == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
         assert(false, "lock with period == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -91,7 +91,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock over _maxLockingPeriod should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),6001);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),6001);
         assert(false, "lock over _maxLockingPeriod should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -100,20 +100,20 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       await helpers.increaseTime(101);
       tx = await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Release");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._beneficiary,accounts[0]);
     });
 
     it("release before locking period should revert", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       try {
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -125,7 +125,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release cannot release twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(101);
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -139,7 +139,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         tx = await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -153,11 +153,11 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem score ", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100 ,{from:accounts[0]});
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100 ,{from:accounts[0]});
         var lockingId1 = await helpers.getValueFromLogs(tx, '_lockingId',1);
-        await testSetup.lockingToken.transfer(accounts[1],web3.toWei('1', "ether"));
-        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"),{from:accounts[1]});
-        tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),300 ,{from:accounts[1]});
+        await testSetup.lockingToken.transfer(accounts[1],web3.utils.toWei('1', "ether"));
+        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"),{from:accounts[1]});
+        tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),300 ,{from:accounts[1]});
         var lockingId2 = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId1);
@@ -168,7 +168,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem cannot redeem twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -182,7 +182,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem before lockingEndTime should revert", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(50);
         try {

--- a/test/organizationregister.js
+++ b/test/organizationregister.js
@@ -38,12 +38,12 @@ const setup = async function (accounts) {
    return testSetup;
 };
 
-contract('OrganizationRegister', function(accounts) {
+contract('OrganizationRegister',accounts => {
   before(function() {
-    helpers.etherForEveryone();
+     helpers.etherForEveryone(accounts);
   });
 
-   it("setParameters", async function() {
+   it("setParameters", async() => {
      var organizationRegister = await OrganizationRegister.new();
      await organizationRegister.setParameters(accounts[3],13,accounts[2]);
      var paramHash = await organizationRegister.getParametersHash(accounts[3],13,accounts[2]);

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -39,9 +39,9 @@ const setup = async function (accounts) {
 
    return testSetup;
 };
-contract('SchemeRegistrar', function(accounts) {
+contract('SchemeRegistrar', accounts => {
 
-   it("setParameters", async function() {
+   it("setParameters", async() => {
      var schemeRegistrar = await SchemeRegistrar.new();
      var params = await setupSchemeRegistrarParams(schemeRegistrar);
      var parameters = await schemeRegistrar.parameters(params.paramsHash);
@@ -51,7 +51,7 @@ contract('SchemeRegistrar', function(accounts) {
     it("proposeScheme log", async function() {
       var testSetup = await setup(accounts);
 
-      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,testSetup.schemeRegistrar.address,0,false);
+      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,testSetup.schemeRegistrar.address,helpers.NULL_HASH,"0x00000000");
       assert.equal(tx.logs.length, 1);
       assert.equal(tx.logs[0].event, "NewSchemeProposal");
      });
@@ -59,7 +59,7 @@ contract('SchemeRegistrar', function(accounts) {
       it("proposeScheme check owner vote", async function() {
         var testSetup = await setup(accounts);
 
-        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,testSetup.schemeRegistrar.address,0,false);
+        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,testSetup.schemeRegistrar.address,helpers.NULL_HASH,"0x00000000");
         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
         await helpers.checkVoteInfo(testSetup.schemeRegistrarParams.votingMachine.absoluteVote,proposalId,accounts[0],[1,testSetup.reputationArray[0]]);
        });
@@ -83,7 +83,7 @@ contract('SchemeRegistrar', function(accounts) {
     it("execute proposeScheme  and execute -yes - fee > 0 ", async function() {
       var testSetup = await setup(accounts);
       var universalScheme = await UniversalScheme.new();
-      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,0,false);
+      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,helpers.NULL_HASH,"0x00000000");
       //Vote with reputation to trigger execution
       var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
       await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -95,7 +95,7 @@ contract('SchemeRegistrar', function(accounts) {
        var testSetup = await setup(accounts);
        var permissions = "0x00000001";
 
-       var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,permissions);
+       var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,permissions);
        //Vote with reputation to trigger execution
        var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
        await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -108,7 +108,7 @@ contract('SchemeRegistrar', function(accounts) {
         var testSetup = await setup(accounts);
         var permissions = "0x00000002";
 
-        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,permissions);
+        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,permissions);
         //Vote with reputation to trigger execution
         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
         await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -121,7 +121,7 @@ contract('SchemeRegistrar', function(accounts) {
          var testSetup = await setup(accounts);
          var permissions = "0x00000003";
 
-         var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,permissions);
+         var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,permissions);
          //Vote with reputation to trigger execution
          var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
          await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -134,7 +134,7 @@ contract('SchemeRegistrar', function(accounts) {
           var testSetup = await setup(accounts);
           var permissions = "0x00000008";
 
-          var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,permissions);
+          var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,permissions);
           //Vote with reputation to trigger execution
           var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
           await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -147,7 +147,7 @@ contract('SchemeRegistrar', function(accounts) {
            var testSetup = await setup(accounts);
            var permissions = "0x00000010";
 
-           var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,permissions);
+           var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,permissions);
            //Vote with reputation to trigger execution
            var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
            await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -158,9 +158,8 @@ contract('SchemeRegistrar', function(accounts) {
 
       it("execute proposeScheme  and execute -yes - isRegistering==FALSE ", async function() {
         var testSetup = await setup(accounts);
-        var isRegistering = false;
 
-        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,isRegistering);
+        var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,"0x00000000");
         //Vote with reputation to trigger execution
         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
         await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -173,9 +172,8 @@ contract('SchemeRegistrar', function(accounts) {
 
        it("execute proposeScheme - no decision (same for remove scheme) - proposal data delete", async function() {
          var testSetup = await setup(accounts);
-         var isRegistering = false;
 
-         var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],0,isRegistering);
+         var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,accounts[0],helpers.NULL_HASH,"0x00000000");
          var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
          //check organizationsProposals before execution
          var organizationProposal = await testSetup.schemeRegistrar.organizationsProposals(testSetup.org.avatar.address,proposalId);
@@ -209,7 +207,7 @@ contract('SchemeRegistrar', function(accounts) {
      var testSetup = await setup(accounts);
 
      var universalScheme = await UniversalScheme.new();
-     var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,0,false);
+     var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,helpers.NULL_HASH,"0x00000000");
      //Vote with reputation to trigger execution
      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
      await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
@@ -219,7 +217,7 @@ contract('SchemeRegistrar', function(accounts) {
       var testSetup = await setup(accounts);
 
       var universalScheme = await UniversalScheme.new();
-      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,0,false);
+      var tx = await testSetup.schemeRegistrar.proposeScheme(testSetup.org.avatar.address,universalScheme.address,helpers.NULL_HASH,"0x00000000");
       //Vote with reputation to trigger execution
       var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
       await testSetup.schemeRegistrarParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});

--- a/test/simpleico.js
+++ b/test/simpleico.js
@@ -13,8 +13,8 @@ const setupSimpleICOParams = async function(accounts,
                                             org,
                                             cap=10000,
                                             price=1,
-                                            startBlock=web3.eth.blockNumber,
-                                            endBlock=web3.eth.blockNumber+500) {
+                                            startBlock=0,
+                                            endBlock=500) {
   // Register ICO parameters
   let beneficiary = org.avatar.address;
   let admin = accounts[0];
@@ -37,28 +37,29 @@ const setup = async function (accounts,cap =10000,price=1) {
   testSetup.standardTokenMock = await StandardTokenMock.new(accounts[1],100);
   testSetup.simpleICO = await SimpleICO.new();
   testSetup.org = await setupOrganization(accounts[0],1000,1000);
-  testSetup.paramHash= await setupSimpleICOParams(accounts,testSetup.simpleICO,testSetup.org,cap,price);
+  const blockNumber = await web3.eth.getBlockNumber();
+  testSetup.paramHash= await setupSimpleICOParams(accounts,testSetup.simpleICO,testSetup.org,cap,price,blockNumber,blockNumber+500);
   await daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.simpleICO.address],[testSetup.paramHash],["0x00000000"]);
   return testSetup;
 };
 
-contract('SimpleICO', function(accounts) {
+contract('SimpleICO', accounts => {
 
   before(function() {
-    helpers.etherForEveryone();
+    helpers.etherForEveryone(accounts);
   });
 
-  it("simpleICO send ether to contract - should revert", async function() {
+  it("simpleICO send ether to contract - should revert", async () => {
     var simpleICO = await SimpleICO.new();
-    var account1BalanceBefore = web3.eth.getBalance(accounts[1])/web3.toWei('1', "ether");
+    var account1BalanceBefore = await web3.eth.getBalance(accounts[1])/web3.utils.toWei('1', "ether");
     try{
-    await web3.eth.sendTransaction({from:accounts[1],to:simpleICO.address, value: web3.toWei('1', "ether")});
+    await web3.eth.sendTransaction({from:accounts[1],to:simpleICO.address, value: web3.utils.toWei('1', "ether")});
     assert(false,"should fail - contract simpleICO should not receive ethers and should revert in this case");
    }
    catch(ex){
      helpers.assertVMException(ex);
    }
-   var account1BalanceAfter = web3.eth.getBalance(accounts[1])/web3.toWei('1', "ether");
+   var account1BalanceAfter = await web3.eth.getBalance(accounts[1])/web3.utils.toWei('1', "ether");
    assert.equal(Math.round(account1BalanceAfter),Math.round(account1BalanceBefore));
   });
 
@@ -93,7 +94,13 @@ contract('SimpleICO', function(accounts) {
         var standardTokenMock = await StandardTokenMock.new(accounts[1],100);
         var simpleICO = await SimpleICO.new();
         var org = await setupOrganization(accounts[0],1000,1000);
-        var paramHash= await setupSimpleICOParams(accounts,simpleICO,org,1000,1,web3.eth.blockNumber+100,web3.eth.blockNumber+100+500);
+        var paramHash= await setupSimpleICOParams(accounts,
+                                                  simpleICO,
+                                                  org,
+                                                  1000,
+                                                  1,
+                                                  (await web3.eth.getBlockNumber())+100,
+                                                  (await web3.eth.getBlockNumber())+100+500);
         //give some tokens to organization avatar so it could register the universal scheme.
         await standardTokenMock.transfer(org.avatar.address,30,{from:accounts[1]});
         await daoCreator.setSchemes(org.avatar.address,[simpleICO.address],[paramHash],["0x8000000F"]);
@@ -105,7 +112,7 @@ contract('SimpleICO', function(accounts) {
         var standardTokenMock = await StandardTokenMock.new(accounts[1],100);
         var simpleICO = await SimpleICO.new();
         var org = await setupOrganization(accounts[0],1000,1000);
-        var paramHash= await setupSimpleICOParams(accounts,simpleICO,org,1000,1,web3.eth.blockNumber,web3.eth.blockNumber);
+        var paramHash= await setupSimpleICOParams(accounts,simpleICO,org,1000,1,(await web3.eth.blockNumber),(await web3.eth.blockNumber));
         //give some tokens to organization avatar so it could register the universal scheme.
         await standardTokenMock.transfer(org.avatar.address,30,{from:accounts[1]});
         await daoCreator.setSchemes(org.avatar.address,[simpleICO.address],[paramHash],["0x8000000F"]);
@@ -120,7 +127,13 @@ contract('SimpleICO', function(accounts) {
         var standardTokenMock = await StandardTokenMock.new(accounts[1],100);
         var simpleICO = await SimpleICO.new();
         var org = await setupOrganization(accounts[0],1000,1000);
-        var paramHash= await setupSimpleICOParams(accounts,simpleICO,org,cap,price);
+        var paramHash= await setupSimpleICOParams(accounts,
+                                                  simpleICO,
+                                                  org,
+                                                  cap,
+                                                  price,
+                                                  await web3.eth.getBlockNumber(),
+                                                  await web3.eth.getBlockNumber()+500);
         //give some tokens to organization avatar so it could register the universal scheme.
         await standardTokenMock.transfer(org.avatar.address,30,{from:accounts[1]});
         await daoCreator.setSchemes(org.avatar.address,[simpleICO.address],[paramHash],["0x8000000F"]);
@@ -265,12 +278,12 @@ contract('SimpleICO', function(accounts) {
                   await testSetup.simpleICO.start(testSetup.org.avatar.address);
                   var donationEther = cap+10;
                   let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-                  var beneficiaryBalance = web3.eth.getBalance(otherAvatar.address);
+                  var beneficiaryBalance = await web3.eth.getBalance(otherAvatar.address);
                   assert.equal(beneficiaryBalance,0);
                   await testSetup.simpleICO.donate(testSetup.org.avatar.address,otherAvatar.address,{value:donationEther});
                   var balance = await testSetup.org.token.balanceOf(otherAvatar.address);
                   assert.equal(balance.toNumber(),price*cap);
-                  beneficiaryBalance = web3.eth.getBalance(otherAvatar.address);
+                  beneficiaryBalance = await web3.eth.getBalance(otherAvatar.address);
                   assert.equal(beneficiaryBalance,10);
                 });
 
@@ -280,7 +293,7 @@ contract('SimpleICO', function(accounts) {
               var testSetup = await setup(accounts,cap,price);
               await testSetup.simpleICO.start(testSetup.org.avatar.address);
               let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-              var beneficiaryBalance = web3.eth.getBalance(otherAvatar.address);
+              var beneficiaryBalance = await web3.eth.getBalance(otherAvatar.address);
               assert.equal(beneficiaryBalance,0);
               var organization = await testSetup.simpleICO.organizationsICOInfo(testSetup.org.avatar.address);
               var mirrorContractICO = organization[1];
@@ -298,7 +311,7 @@ contract('SimpleICO', function(accounts) {
                 var cap = 3;
                 var testSetup = await setup(accounts,cap,price);
                 let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-                var beneficiaryBalance = web3.eth.getBalance(otherAvatar.address);
+                var beneficiaryBalance =await web3.eth.getBalance(otherAvatar.address);
                 assert.equal(beneficiaryBalance,0);
                 var organization = await testSetup.simpleICO.organizationsICOInfo(testSetup.org.avatar.address);
                 var mirrorContractICO = organization[1];

--- a/test/simpleico.js
+++ b/test/simpleico.js
@@ -112,7 +112,13 @@ contract('SimpleICO', accounts => {
         var standardTokenMock = await StandardTokenMock.new(accounts[1],100);
         var simpleICO = await SimpleICO.new();
         var org = await setupOrganization(accounts[0],1000,1000);
-        var paramHash= await setupSimpleICOParams(accounts,simpleICO,org,1000,1,(await web3.eth.blockNumber),(await web3.eth.blockNumber));
+        var paramHash= await setupSimpleICOParams(accounts,
+                                                  simpleICO,
+                                                  org,
+                                                  1000,
+                                                  1,
+                                                  await web3.eth.getBlockNumber(),
+                                                  await web3.eth.getBlockNumber());
         //give some tokens to organization avatar so it could register the universal scheme.
         await standardTokenMock.transfer(org.avatar.address,30,{from:accounts[1]});
         await daoCreator.setSchemes(org.avatar.address,[simpleICO.address],[paramHash],["0x8000000F"]);

--- a/test/tokencapgc.js
+++ b/test/tokencapgc.js
@@ -7,10 +7,9 @@ const Avatar = artifacts.require("./Avatar.sol");
 var constants = require('../test/constants');
 
 
-let reputation, avatar,accounts,token,controller;
+let reputation, avatar,token,controller;
 const setup = async function (permission='0') {
   var _controller;
-  accounts = web3.eth.accounts;
   token  = await DAOToken.new("TEST","TST",0);
   // set up a reputation system
   reputation = await Reputation.new();
@@ -27,7 +26,7 @@ const setup = async function (permission='0') {
   return _controller;
 };
 
-contract('TokenCapGC', function (accounts)  {
+contract('TokenCapGC', accounts =>  {
     it("setParameters", async () => {
       var paramsHash;
       var tokenCapGC = await TokenCapGC.new();
@@ -44,14 +43,14 @@ contract('TokenCapGC', function (accounts)  {
     var token  = await DAOToken.new("TEST","TST",0);
     await tokenCapGC.setParameters(token.address,100);
     paramsHash = await tokenCapGC.getParametersHash(token.address,100);
-    pre = await tokenCapGC.pre(token.address,paramsHash,0);
+    pre = await tokenCapGC.pre(token.address,paramsHash,helpers.NULL_HASH);
     assert.equal(pre,true);
-    post = await tokenCapGC.post(token.address,paramsHash,0);
+    post = await tokenCapGC.post(token.address,paramsHash,helpers.NULL_HASH);
     //token total supply is 0
     assert.equal(post,true);
     //increase the total supply
     await token.mint(accounts[2], 101);
-    post = await tokenCapGC.post(token.address,paramsHash,0);
+    post = await tokenCapGC.post(token.address,paramsHash,helpers.NULL_HASH);
     //token total supply is 101
     assert.equal(post,false);
   });
@@ -62,12 +61,12 @@ contract('TokenCapGC', function (accounts)  {
     var token  = await DAOToken.new("TEST","TST",0);
     await tokenCapGC.setParameters(token.address,100);
     await tokenCapGC.getParametersHash(token.address,100);
-    post = await tokenCapGC.post(token.address,1,0);
+    post = await tokenCapGC.post(token.address,"0x0001",helpers.NULL_HASH);
     //token total supply is 0
     assert.equal(post,true);
     //increase the total supply
     await token.mint(accounts[2], 101);
-    post = await tokenCapGC.post(token.address,1,0);
+    post = await tokenCapGC.post(token.address,"0x0001",helpers.NULL_HASH);
     //token total supply is 101
     assert.equal(post,true);
   });

--- a/test/ucontroller.js
+++ b/test/ucontroller.js
@@ -13,10 +13,8 @@ var uint32 = require('uint32');
 
 let reputation, avatar,token,controller;
 var amountToMint = 10;
-let accounts = web3.eth.accounts;
 
-
-const setup = async function (permission='0x00000000',registerScheme = accounts[0]) {
+const setup = async function (accounts,permission='0x00000000',registerScheme = accounts[0]) {
   var uController = await UController.new({gas: constants.ARC_GAS_LIMIT});
   token  = await DAOToken.new("TEST","TST",0);
   // set up a reputation system
@@ -25,7 +23,7 @@ const setup = async function (permission='0x00000000',registerScheme = accounts[
   await avatar.transferOwnership(uController.address);
   if (permission !== '0x00000000'){
     await uController.newOrganization(avatar.address,{from:accounts[1]});
-    await uController.registerScheme(registerScheme,0,permission,avatar.address,{from:accounts[1]});
+    await uController.registerScheme(registerScheme,helpers.NULL_HASH,permission,avatar.address,{from:accounts[1]});
     await uController.unregisterSelf(0,{from:accounts[1]});
   }
   else {
@@ -37,18 +35,18 @@ const setup = async function (permission='0x00000000',registerScheme = accounts[
 const constraint = async function (method, pre=false, post=false) {
   var globalConstraints = await GlobalConstraintMock.new();
   let globalConstraintsCountOrig = await controller.globalConstraintsCount(avatar.address);
-  await globalConstraints.setConstraint(method,pre,post);
-  await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
+  await globalConstraints.setConstraint(web3.utils.asciiToHex(method),pre,post);
+  await controller.addGlobalConstraint(globalConstraints.address,helpers.NULL_HASH,avatar.address);
   let globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
   assert.equal(globalConstraintsCount[0].toNumber(),globalConstraintsCountOrig[0].toNumber() + (pre ? 0 : 1));
   assert.equal(globalConstraintsCount[1].toNumber(),globalConstraintsCountOrig[1].toNumber() + (post ? 0 : 1));
   return globalConstraints;
 };
 
-contract('UController', function (accounts)  {
+contract('UController',accounts =>  {
 
-   it("getGlobalConstraintParameters", async function() {
-        controller = await setup();
+   it("getGlobalConstraintParameters", async() => {
+        controller = await setup(accounts);
         // separate cases for pre and post
         var globalConstraints = await constraint("gcParams1", true);
         await controller.addGlobalConstraint(globalConstraints.address,"0x1235",avatar.address);
@@ -67,7 +65,6 @@ contract('UController', function (accounts)  {
 
   it("newOrganization without controller owner of the avatar", async () => {
     var uController = await UController.new({gas: constants.ARC_GAS_LIMIT});
-    accounts = web3.eth.accounts;
     token  = await DAOToken.new("TEST","TST",0);
     // set up a reputation system
     reputation = await Reputation.new();
@@ -81,7 +78,7 @@ contract('UController', function (accounts)  {
   });
 
   it("newOrganization with same avatar", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     try {
       await controller.newOrganization(avatar.address);
       assert(false, 'trying to call new organization with an avatar which already registered should fail.');
@@ -91,7 +88,7 @@ contract('UController', function (accounts)  {
   });
 
   it("mint reputation via controller", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     await reputation.transferOwnership(controller.address);
     let tx =  await controller.mintReputation(amountToMint,accounts[0],avatar.address);
     assert.equal(tx.logs.length, 1);
@@ -103,7 +100,7 @@ contract('UController', function (accounts)  {
   });
 
   it("burn reputation via controller", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     await reputation.transferOwnership(controller.address);
     await controller.mintReputation(amountToMint,accounts[0],avatar.address);
     let tx =  await controller.burnReputation(amountToMint-1,accounts[0],avatar.address);
@@ -116,7 +113,7 @@ contract('UController', function (accounts)  {
   });
 
   it("mint tokens via controller", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     await token.transferOwnership(controller.address);
     let tx =  await controller.mintTokens(amountToMint,accounts[0],avatar.address);
     assert.equal(tx.logs.length, 1);
@@ -127,8 +124,8 @@ contract('UController', function (accounts)  {
   });
 
   it("register schemes", async () => {
-    controller = await  setup();
-    let tx =  await controller.registerScheme(accounts[1], 0,0,avatar.address);
+    controller = await  setup(accounts);
+    let tx =  await controller.registerScheme(accounts[1], helpers.NULL_HASH,"0x00000000",avatar.address);
     assert.equal(tx.logs.length, 1);
     assert.equal(tx.logs[0].event, "RegisterScheme");
   });
@@ -139,12 +136,12 @@ contract('UController', function (accounts)  {
     var controller;
     for(j = 0; j <= 15; j++ ){
       //registered scheme has already permission to register(2)
-      controller = await setup('0x'+uint32.toHex(j|2));
+      controller = await setup(accounts,'0x'+uint32.toHex(j|2));
       var  register;
       for(i = 0; i <= 15; i++ ){
         register = true;
         try {
-          await controller.registerScheme(accounts[1],0,'0x'+uint32.toHex(i),avatar.address);
+          await controller.registerScheme(accounts[1],helpers.NULL_HASH,'0x'+uint32.toHex(i),avatar.address);
         } catch (ex) {
           //registered scheme has already permission to register(2) and is register(1).
           assert.notEqual(i&(~(j|3),0));
@@ -160,15 +157,15 @@ contract('UController', function (accounts)  {
 
   it("register schemes - check permissions for updating existing scheme", async () => {
     // Check scheme has at least the permissions it is changing, and at least the current permissions.
-    controller = await  setup('0x0000000F');
+    controller = await  setup(accounts,'0x0000000F');
     // scheme with permission 0x0000000F should be able to register scheme with permission 0x00000001
-    let tx = await controller.registerScheme(accounts[0],0,'0x'+uint32.toHex(1),avatar.address);
+    let tx = await controller.registerScheme(accounts[0],helpers.NULL_HASH,"0x00000001",avatar.address);
     assert.equal(tx.logs.length, 1);
     assert.equal(tx.logs[0].event, "RegisterScheme");
 
-    controller = await setup('0x00000001');
+    controller = await setup(accounts,'0x00000001');
     try {
-      await controller.registerScheme(accounts[0],0,'0x'+uint32.toHex(2),avatar.address);
+      await controller.registerScheme(accounts[0],helpers.NULL_HASH,"0x00000002",avatar.address);
       assert(false, 'scheme with permission 0x00000001 should not be able to register scheme with permission 0x00000002');
     } catch (ex) {
       helpers.assertVMException(ex);
@@ -176,13 +173,13 @@ contract('UController', function (accounts)  {
   });
 
   it("unregister schemes", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
     assert.equal(tx.logs.length, 1);
     assert.equal(tx.logs[0].event, "UnregisterScheme");
   });
   it("unregister none registered scheme", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     let tx =  await controller.unregisterScheme(accounts[1],avatar.address);
     assert.equal(tx.logs.length, 0);
   });
@@ -190,7 +187,7 @@ contract('UController', function (accounts)  {
   it("unregister schemes - check permissions unregister scheme", async () => {
     // Check scheme has at least the permissions it is changing, and at least the current permissions.
     //1. setup
-    controller = await  setup();
+    controller = await  setup(accounts);
     //2. account[0] register schemes ,on account[1] with variables permissions which could unregister other schemes.
     var i,j;
     var tx;
@@ -198,11 +195,11 @@ contract('UController', function (accounts)  {
     var unregisteredScheme = accounts[2];
     for(i = 0; i <= 15; i++ ){
       //registered scheme has already permission to register(2)
-      tx = await controller.registerScheme(registeredScheme,0,'0x'+uint32.toHex(i|3),avatar.address);
+      tx = await controller.registerScheme(registeredScheme,helpers.NULL_HASH,'0x'+uint32.toHex(i|3),avatar.address);
       assert.equal(tx.logs.length, 1);
       assert.equal(tx.logs[0].event, "RegisterScheme");
       for(j = 0; j <= 15; j++ ){
-        tx = await controller.registerScheme(unregisteredScheme,0,'0x'+uint32.toHex(j),avatar.address);
+        tx = await controller.registerScheme(unregisteredScheme,helpers.NULL_HASH,'0x'+uint32.toHex(j),avatar.address);
         assert.equal(tx.logs.length, 1);
         assert.equal(tx.logs[0].event, "RegisterScheme");
         //try to unregisterScheme
@@ -226,7 +223,7 @@ contract('UController', function (accounts)  {
 
   it("unregister self", async () => {
     var tx;
-    controller = await  setup("0x00000000");
+    controller = await  setup(accounts,"0x00000000");
     tx = await controller.unregisterSelf(avatar.address,{ from: accounts[1]});
     assert.equal(tx.logs.length, 0); // scheme was not registered
 
@@ -237,7 +234,7 @@ contract('UController', function (accounts)  {
 
   it("isSchemeRegistered ", async () => {
     var isSchemeRegistered;
-    controller = await  setup("0x00000000");
+    controller = await  setup(accounts,"0x00000000");
     isSchemeRegistered = await controller.isSchemeRegistered(accounts[1],avatar.address);
     assert.equal(isSchemeRegistered, false);
     isSchemeRegistered = await controller.isSchemeRegistered(accounts[0],avatar.address);
@@ -245,9 +242,9 @@ contract('UController', function (accounts)  {
   });
 
   it("addGlobalConstraint ", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     var globalConstraints = await constraint("0");
-    var tx = await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
+    var tx = await controller.addGlobalConstraint(globalConstraints.address,helpers.NULL_HASH,avatar.address);
     assert.equal(await controller.isGlobalConstraintRegistered(globalConstraints.address,avatar.address),true);
     assert.equal(tx.logs.length, 1);
     assert.equal(tx.logs[0].event, "AddGlobalConstraint");
@@ -256,24 +253,24 @@ contract('UController', function (accounts)  {
   });
 
   it("removeGlobalConstraint ", async () => {
-    controller = await setup();
+    controller = await setup(accounts);
     var globalConstraints = await GlobalConstraintMock.new();
-    await globalConstraints.setConstraint("0",false,false);
+    await globalConstraints.setConstraint(web3.utils.asciiToHex("0"),false,false);
     var globalConstraints1 = await GlobalConstraintMock.new();
-    await globalConstraints1.setConstraint("method",false,false);
+    await globalConstraints1.setConstraint(web3.utils.asciiToHex("method"),false,false);
     var globalConstraints2 = await GlobalConstraintMock.new();
-    await globalConstraints2.setConstraint("method",false,false);
+    await globalConstraints2.setConstraint(web3.utils.asciiToHex("method"),false,false);
     var globalConstraints3 = await GlobalConstraintMock.new();
-    await globalConstraints3.setConstraint("method",false,false);
+    await globalConstraints3.setConstraint(web3.utils.asciiToHex("method"),false,false);
     var globalConstraints4 = await GlobalConstraintMock.new();
-    await globalConstraints4.setConstraint("method",false,false);
+    await globalConstraints4.setConstraint(web3.utils.asciiToHex("method"),false,false);
 
     assert.equal(await controller.isGlobalConstraintRegistered(globalConstraints.address,avatar.address),false);
-    await controller.addGlobalConstraint(globalConstraints.address,0,avatar.address);
-    await controller.addGlobalConstraint(globalConstraints1.address,0,avatar.address);
-    await controller.addGlobalConstraint(globalConstraints2.address,0,avatar.address);
-    await controller.addGlobalConstraint(globalConstraints3.address,0,avatar.address);
-    await controller.addGlobalConstraint(globalConstraints4.address,0,avatar.address);
+    await controller.addGlobalConstraint(globalConstraints.address,helpers.NULL_HASH,avatar.address);
+    await controller.addGlobalConstraint(globalConstraints1.address,helpers.NULL_HASH,avatar.address);
+    await controller.addGlobalConstraint(globalConstraints2.address,helpers.NULL_HASH,avatar.address);
+    await controller.addGlobalConstraint(globalConstraints3.address,helpers.NULL_HASH,avatar.address);
+    await controller.addGlobalConstraint(globalConstraints4.address,helpers.NULL_HASH,avatar.address);
     var tx = await controller.removeGlobalConstraint(globalConstraints2.address,avatar.address);
     assert.equal(tx.logs.length, 2);
     assert.equal(tx.logs[0].event, "RemoveGlobalConstraint");
@@ -296,7 +293,7 @@ contract('UController', function (accounts)  {
   });
 
   it("upgrade controller ", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
 
     await reputation.transferOwnership(controller.address);
     await token.transferOwnership(controller.address);
@@ -306,7 +303,7 @@ contract('UController', function (accounts)  {
   });
 
   it("upgrade controller check permission", async () => {
-    controller = await  setup('0x00000007');
+    controller = await  setup(accounts,'0x00000007');
     await token.transferOwnership(controller.address);
     await reputation.transferOwnership(controller.address);
     try{
@@ -318,94 +315,99 @@ contract('UController', function (accounts)  {
   });
 
   it("generic call log", async () => {
-    controller = await setup('0x00000010');
+    controller = await setup(accounts,'0x00000010');
     let actionMock =  await ActionMock.new();
     let a = 7;
     let b = actionMock.address;
-    let c = 0x1234;
-    const extraData = await actionMock.test.request(a,b,c);
-    var tx = await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-    var log = await new Promise((resolve) => {
-                    avatar.GenericCall({fromBlock: tx.blockNumber})
-                        .get((err,events) => {
-                                resolve(events);
-                        });
-                    });
-    assert.equal(log[0].args._contract,actionMock.address);
+    let c = "0x1234";
+    const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+    var tx = await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+    await avatar.getPastEvents('GenericCall', {
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"GenericCall");
+          assert.equal(events[0].args._contract,actionMock.address);
+      });
 
   });
 
   it("generic call", async () => {
-    controller = await setup('0x00000010');
+    controller = await setup(accounts,'0x00000010');
     let actionMock =  await ActionMock.new();
     let a = 7;
     let b = actionMock.address;
-    let c = 0x1234;
-    const extraData = await actionMock.test.request(a,b,c);
-    var result = await controller.genericCall.call(actionMock.address,extraData.params[0].data,avatar.address);
+    let c = "0x1234";
+    const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+    var result = await controller.genericCall.call(actionMock.address,encodeABI,avatar.address);
     assert.equal(result, 14);
 
   });
     it("generic call withoutReturnValue", async () => {
-      controller = await setup('0x00000010');
+      controller = await setup(accounts,'0x00000010');
       let actionMock =  await ActionMock.new();
-      const extraData = await actionMock.withoutReturnValue.request(avatar.address);
-      var tx = await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-      const log = await new Promise((resolve) => {
-                  actionMock.WithoutReturnValue({_addr: avatar.address}, {fromBlock: tx.blockNumber})
-                      .get((err,events) => {
-                              resolve(events);
-                      });
-                  });
-      assert.equal(log[0].event,"WithoutReturnValue");
+      const actionMockContract = await new web3.eth.Contract(actionMock.abi);
+      const encodeABI = actionMockContract.methods.withoutReturnValue(avatar.address).encodeABI();
+      var tx = await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+      await actionMock.getPastEvents('WithoutReturnValue', {
+            filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+            fromBlock: tx.blockNumber,
+            toBlock: 'latest'
+        })
+        .then(function(events){
+            assert.equal(events[0].event,"WithoutReturnValue");
+        });
     });
 
   it("generic call via contract scheme", async () => {
     var scheme = await UniversalSchemeMock.new();
-    controller = await setup('0x00000010',scheme.address);
+    controller = await setup(accounts,'0x00000010',scheme.address);
     let actionMock =  await ActionMock.new();
     let a = 7;
     let b = actionMock.address;
-    let c = 0x1234;
+    let c = "0x1234";
     let result = await scheme.genericCall.call(avatar.address,actionMock.address, a,b,c);
     assert.equal(result, 14);
 
   });
 
   it("sendEther", async () => {
-    controller = await  setup();
+    controller = await  setup(accounts);
     let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
     //send some ether to the avatar
-    web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.toWei('1', "ether")});
+    await web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.utils.toWei('1', "ether")});
     //send some ether from an organization's avatar to the otherAvatar
-    var tx = await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-    const log = await new Promise((resolve) => {
-                avatar.SendEther({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"SendEther");
-    var avatarBalance = web3.eth.getBalance(avatar.address)/web3.toWei('1', "ether");
+    var tx = await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+    await avatar.getPastEvents('SendEther', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"SendEther");
+      });
+    var avatarBalance = await web3.eth.getBalance(avatar.address)/web3.utils.toWei('1', "ether");
     assert.equal(avatarBalance, 0);
-    var otherAvatarBalance = web3.eth.getBalance(otherAvatar.address)/web3.toWei('1', "ether");
+    var otherAvatarBalance = await web3.eth.getBalance(otherAvatar.address)/web3.utils.toWei('1', "ether");
     assert.equal(otherAvatarBalance, 1);
   });
 
   it("externalTokenTransfer", async () => {
     //External transfer token from avatar contract to other address
-    controller = await  setup();
+    controller = await  setup(accounts);
     var standardToken = await StandardTokenMock.new(avatar.address, 100);
     let balanceAvatar = await standardToken.balanceOf(avatar.address);
     assert.equal(balanceAvatar, 100);
     var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-    const log = await new Promise((resolve) => {
-                avatar.ExternalTokenTransfer({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"ExternalTokenTransfer");
+    await avatar.getPastEvents('ExternalTokenTransfer', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"ExternalTokenTransfer");
+      });
     balanceAvatar = await standardToken.balanceOf(avatar.address);
     assert.equal(balanceAvatar, 50);
     let balance1 = await standardToken.balanceOf(accounts[1]);
@@ -415,27 +417,27 @@ contract('UController', function (accounts)  {
   it("externalTokenTransferFrom & ExternalTokenIncreaseApproval", async () => {
     var tx;
     var to   = accounts[1];
-    controller = await  setup();
+    controller = await  setup(accounts);
     var standardToken = await StandardTokenMock.new(avatar.address, 100);
     tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-    var log = await new Promise((resolve) => {
-                avatar.ExternalTokenIncreaseApproval({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"ExternalTokenIncreaseApproval");
-
+    await avatar.getPastEvents('ExternalTokenIncreaseApproval', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"ExternalTokenIncreaseApproval");
+      });
     tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
 
-    log = await new Promise((resolve) => {
-                avatar.ExternalTokenTransferFrom({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"ExternalTokenTransferFrom");
-
+    await avatar.getPastEvents('ExternalTokenTransferFrom', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"ExternalTokenTransferFrom");
+      });
     let balanceAvatar = await standardToken.balanceOf(avatar.address);
     assert.equal(balanceAvatar, 50);
     let balanceTo = await standardToken.balanceOf(to);
@@ -446,19 +448,19 @@ contract('UController', function (accounts)  {
   it("externalTokenTransferFrom & externalTokenDecreaseApproval", async () => {
     var tx;
     var to   = accounts[1];
-    controller = await  setup();
+    controller = await  setup(accounts);
     var standardToken = await StandardTokenMock.new(avatar.address, 100);
     tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
     tx = await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
 
-    var log = await new Promise((resolve) => {
-                avatar.ExternalTokenDecreaseApproval({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"ExternalTokenDecreaseApproval");
-
+    await avatar.getPastEvents('ExternalTokenDecreaseApproval', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"ExternalTokenDecreaseApproval");
+      });
 
     try{
       await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
@@ -469,266 +471,269 @@ contract('UController', function (accounts)  {
     }
     tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
     tx=  await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-    log = await new Promise((resolve) => {
-                avatar.ExternalTokenTransferFrom({fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                            resolve(events);
-                    });
-                });
-    assert.equal(log[0].event,"ExternalTokenTransferFrom");
+    await avatar.getPastEvents('ExternalTokenTransferFrom', {
+          filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+          fromBlock: tx.blockNumber,
+          toBlock: 'latest'
+      })
+      .then(function(events){
+          assert.equal(events[0].event,"ExternalTokenTransferFrom");
+      });
     let balanceAvatar = await standardToken.balanceOf(avatar.address);
     assert.equal(balanceAvatar, 50);
     let balanceTo = await standardToken.balanceOf(to);
     assert.equal(balanceTo, 50);
   });
-        it("globalConstraints mintReputation add & remove", async () => {
-          controller = await  setup();
-          var globalConstraints = await constraint("mintReputation");
-          await reputation.transferOwnership(controller.address);
-          try {
-          await controller.mintReputation(amountToMint,accounts[0],avatar.address);
-          assert(false,"mint reputation should fail due to the global constraint ");
-          }
-          catch(ex){
-            helpers.assertVMException(ex);
-          }
-          await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-          var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-          assert.equal(globalConstraintsCount[0],0);
-          assert.equal(globalConstraintsCount[1],0);
-          let tx = await controller.mintReputation(amountToMint,accounts[0],avatar.address);
-          assert.equal(tx.logs.length, 1);
-          assert.equal(tx.logs[0].event, "MintReputation");
-          assert.equal(tx.logs[0].args._amount, amountToMint);
-          let rep = await reputation.reputationOf(accounts[0]);
-          assert.equal(rep,amountToMint);
+    it("globalConstraints mintReputation add & remove", async () => {
+      controller = await  setup(accounts);
+      var globalConstraints = await constraint("mintReputation");
+      await reputation.transferOwnership(controller.address);
+      try {
+      await controller.mintReputation(amountToMint,accounts[0],avatar.address);
+      assert(false,"mint reputation should fail due to the global constraint ");
+      }
+      catch(ex){
+        helpers.assertVMException(ex);
+      }
+      await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+      var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+      assert.equal(globalConstraintsCount[0],0);
+      assert.equal(globalConstraintsCount[1],0);
+      let tx = await controller.mintReputation(amountToMint,accounts[0],avatar.address);
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "MintReputation");
+      assert.equal(tx.logs[0].args._amount, amountToMint);
+      let rep = await reputation.reputationOf(accounts[0]);
+      assert.equal(rep,amountToMint);
+      });
+
+    it("globalConstraints mintTokens add & remove", async () => {
+
+      controller = await  setup(accounts);
+      var globalConstraints = await constraint("mintTokens");
+      await token.transferOwnership(controller.address);
+      try {
+      await controller.mintTokens(amountToMint,accounts[0],avatar.address);
+      assert(false,"mint tokens should fail due to the global constraint ");
+      }
+      catch(ex){
+        helpers.assertVMException(ex);
+      }
+      await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+      var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+      assert.equal(globalConstraintsCount[0],0);
+      assert.equal(globalConstraintsCount[1],0);
+      let tx =  await controller.mintTokens(amountToMint,accounts[0],avatar.address);
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "MintTokens");
+      assert.equal(tx.logs[0].args._amount, amountToMint);
+      let balance =  await token.balanceOf(accounts[0]);
+      assert.equal(balance,amountToMint);
+      });
+
+   it("globalConstraints register schemes add & remove", async () => {
+      controller = await  setup(accounts);
+      var globalConstraints = await constraint("registerScheme");
+      try {
+      await controller.registerScheme(accounts[1], helpers.NULL_HASH,"0x00000000",avatar.address);
+      assert(false,"registerScheme should fail due to the global constraint ");
+      }
+      catch(ex){
+        helpers.assertVMException(ex);
+      }
+      await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+      var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+      assert.equal(globalConstraintsCount[0],0);
+      assert.equal(globalConstraintsCount[1],0);
+      let tx =  await controller.registerScheme(accounts[1], helpers.NULL_HASH,"0x00000000",avatar.address);
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "RegisterScheme");
+      });
+
+    it("globalConstraints unregister schemes add & remove", async () => {
+       controller = await  setup(accounts);
+       var globalConstraints = await constraint("registerScheme");
+       try {
+       await controller.unregisterScheme(accounts[0],avatar.address);
+       assert(false,"unregisterScheme should fail due to the global constraint ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
+       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+       assert.equal(globalConstraintsCount[0],0);
+       assert.equal(globalConstraintsCount[1],0);
+       let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
+       assert.equal(tx.logs.length, 1);
+       assert.equal(tx.logs[0].event, "UnregisterScheme");
+       });
+
+     it("globalConstraints generic call  add & remove", async () => {
+        controller = await  setup(accounts,'0x00000014');
+        var globalConstraints = await constraint("genericCall");
+        let actionMock =  await ActionMock.new();
+        let a = 7;
+        let b = actionMock.address;
+        let c = "0x1234";
+        const encodeABI = await new web3.eth.Contract(actionMock.abi).methods.test(a,b,c).encodeABI();
+        try {
+          await controller.genericCall.call(actionMock.address,encodeABI,avatar.address);
+          assert(false,"genericAction should fail due to the global constraint ");
+        }
+        catch(ex){
+          helpers.assertVMException(ex);
+        }
+        await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+        var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+        assert.equal(globalConstraintsCount[0],0);
+        assert.equal(globalConstraintsCount[1],0);
+        var tx =  await controller.genericCall(actionMock.address,encodeABI,avatar.address);
+        await avatar.getPastEvents('GenericCall', {
+              filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+              fromBlock: tx.blockNumber,
+              toBlock: 'latest'
+          })
+          .then(function(events){
+              assert.equal(events[0].event,"GenericCall");
           });
+        });
 
-          it("globalConstraints mintTokens add & remove", async () => {
+    it("globalConstraints sendEther  add & remove", async () => {
+       controller = await  setup(accounts);
+       var globalConstraints = await constraint("sendEther");
+       let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
+       web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.utils.toWei('1', "ether")});
 
-            controller = await  setup();
-            var globalConstraints = await constraint("mintTokens");
-            await token.transferOwnership(controller.address);
-            try {
-            await controller.mintTokens(amountToMint,accounts[0],avatar.address);
-            assert(false,"mint tokens should fail due to the global constraint ");
-            }
-            catch(ex){
-              helpers.assertVMException(ex);
-            }
-            await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-            var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-            assert.equal(globalConstraintsCount[0],0);
-            assert.equal(globalConstraintsCount[1],0);
-            let tx =  await controller.mintTokens(amountToMint,accounts[0],avatar.address);
-            assert.equal(tx.logs.length, 1);
-            assert.equal(tx.logs[0].event, "MintTokens");
-            assert.equal(tx.logs[0].args._amount, amountToMint);
-            let balance =  await token.balanceOf(accounts[0]);
-            assert.equal(balance,amountToMint);
-            });
+       try {
+        await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+        assert(false,"sendEther should fail due to the global constraint ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
+       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+       assert.equal(globalConstraintsCount[0],0);
+       assert.equal(globalConstraintsCount[1],0);
+       var tx = await controller.sendEther(web3.utils.toWei('1', "ether"),otherAvatar.address,avatar.address);
+       await avatar.getPastEvents('SendEther', {
+             filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+             fromBlock: tx.blockNumber,
+             toBlock: 'latest'
+         })
+         .then(function(events){
+             assert.equal(events[0].event,"SendEther");
+        });
+       var avatarBalance = await web3.eth.getBalance(avatar.address)/web3.utils.toWei('1', "ether");
+       assert.equal(avatarBalance, 0);
+       var otherAvatarBalance = await web3.eth.getBalance(otherAvatar.address)/web3.utils.toWei('1', "ether");
+       assert.equal(otherAvatarBalance, 1);
+       });
 
-           it("globalConstraints register schemes add & remove", async () => {
-              controller = await  setup();
-              var globalConstraints = await constraint("registerScheme");
-              try {
-              await controller.registerScheme(accounts[1], 0,0,avatar.address);
-              assert(false,"registerScheme should fail due to the global constraint ");
-              }
-              catch(ex){
-                helpers.assertVMException(ex);
-              }
-              await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-              var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-              assert.equal(globalConstraintsCount[0],0);
-              assert.equal(globalConstraintsCount[1],0);
-              let tx =  await controller.registerScheme(accounts[1], 0,0,avatar.address);
-              assert.equal(tx.logs.length, 1);
-              assert.equal(tx.logs[0].event, "RegisterScheme");
-              });
+     it("globalConstraints externalTokenTransfer  add & remove", async () => {
+        controller = await  setup(accounts);
+        var globalConstraints = await constraint("externalTokenTransfer");
+        var standardToken = await StandardTokenMock.new(avatar.address, 100);
+        let balanceAvatar = await standardToken.balanceOf(avatar.address);
+        assert.equal(balanceAvatar, 100);
 
-              it("globalConstraints unregister schemes add & remove", async () => {
-                 controller = await  setup();
-                 var globalConstraints = await constraint("registerScheme");
-                 try {
-                 await controller.unregisterScheme(accounts[0],avatar.address);
-                 assert(false,"unregisterScheme should fail due to the global constraint ");
-                 }
-                 catch(ex){
-                   helpers.assertVMException(ex);
-                 }
-                 await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                 var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                 assert.equal(globalConstraintsCount[0],0);
-                 assert.equal(globalConstraintsCount[1],0);
-                 let tx =  await controller.unregisterScheme(accounts[0],avatar.address);
-                 assert.equal(tx.logs.length, 1);
-                 assert.equal(tx.logs[0].event, "UnregisterScheme");
-                 });
+        try {
+         await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
+         assert(false,"externalTokenTransfer should fail due to the global constraint ");
+        }
+        catch(ex){
+          helpers.assertVMException(ex);
+        }
+        await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+        var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+        assert.equal(globalConstraintsCount[0],0);
+        assert.equal(globalConstraintsCount[1],0);
+        var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
+        await avatar.getPastEvents('ExternalTokenTransfer', {
+              filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+              fromBlock: tx.blockNumber,
+              toBlock: 'latest'
+          })
+          .then(function(events){
+              assert.equal(events[0].event,"ExternalTokenTransfer");
+          });
+        balanceAvatar = await standardToken.balanceOf(avatar.address);
+        assert.equal(balanceAvatar, 50);
+        let balance1 = await standardToken.balanceOf(accounts[1]);
+        assert.equal(balance1, 50);
+        });
 
-                 it("globalConstraints generic call  add & remove", async () => {
-                    controller = await  setup('0x00000014');
-                    var globalConstraints = await constraint("genericCall");
-                    let actionMock =  await ActionMock.new();
-                    let a = 7;
-                    let b = actionMock.address;
-                    let c = 0x1234;
-                    const extraData = await actionMock.test.request(a,b,c);
-                    try {
-                      await controller.genericCall.call(actionMock.address,extraData.params[0].data,avatar.address);
-                      assert(false,"genericAction should fail due to the global constraint ");
-                    }
-                    catch(ex){
-                      helpers.assertVMException(ex);
-                    }
-                    await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                    var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                    assert.equal(globalConstraintsCount[0],0);
-                    assert.equal(globalConstraintsCount[1],0);
-                    var tx =  await controller.genericCall(actionMock.address,extraData.params[0].data,avatar.address);
-                    var log = await new Promise((resolve) => {
-                                    avatar.GenericCall({fromBlock: tx.blockNumber})
-                                        .get((err,events) => {
-                                                resolve(events);
-                                        });
-                                    });
-                    assert.equal(log[0].args._contract,actionMock.address);
-                    });
+    it("globalConstraints externalTokenTransferFrom , externalTokenIncreaseApproval , externalTokenDecreaseApproval", async () => {
+       var tx;
+       var to   = accounts[1];
+       controller = await  setup(accounts);
+       var globalConstraints = await constraint("externalTokenIncreaseApproval");
+       var standardToken = await StandardTokenMock.new(avatar.address, 100);
+       try {
+        await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+        assert(false,"externalTokenIncreaseApproval should fail due to the global constraint ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
+       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+       assert.equal(globalConstraintsCount[0],0);
+       assert.equal(globalConstraintsCount[1],0);
 
-                    it("globalConstraints sendEther  add & remove", async () => {
-                       controller = await  setup();
-                       var globalConstraints = await constraint("sendEther");
-                       let otherAvatar = await Avatar.new('otheravatar', helpers.NULL_ADDRESS, helpers.NULL_ADDRESS);
-                       web3.eth.sendTransaction({from:accounts[0],to:avatar.address, value: web3.toWei('1', "ether")});
+       tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+       await avatar.getPastEvents('ExternalTokenIncreaseApproval', {
+             filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+             fromBlock: tx.blockNumber,
+             toBlock: 'latest'
+         })
+         .then(function(events){
+             assert.equal(events[0].event,"ExternalTokenIncreaseApproval");
+         });
+       globalConstraints = await constraint("externalTokenTransferFrom");
+       try {
+        await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+        assert(false,"externalTokenTransferFrom should fail due to the global constraint ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
+       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+       globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
+       assert.equal(globalConstraintsCount[0],0);
 
-                       try {
-                        await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-                        assert(false,"sendEther should fail due to the global constraint ");
-                       }
-                       catch(ex){
-                         helpers.assertVMException(ex);
-                       }
-                       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                       var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                       assert.equal(globalConstraintsCount[0],0);
-                       assert.equal(globalConstraintsCount[1],0);
-                       var tx = await controller.sendEther(web3.toWei('1', "ether"),otherAvatar.address,avatar.address);
-                       const log = await new Promise((resolve) => {
-                                   avatar.SendEther({fromBlock: tx.blockNumber})
-                                       .get((err,events) => {
-                                               resolve(events);
-                                       });
-                                   });
-                       assert.equal(log[0].event,"SendEther");
-                       var avatarBalance = web3.eth.getBalance(avatar.address)/web3.toWei('1', "ether");
-                       assert.equal(avatarBalance, 0);
-                       var otherAvatarBalance = web3.eth.getBalance(otherAvatar.address)/web3.toWei('1', "ether");
-                       assert.equal(otherAvatarBalance, 1);
-                       });
+       globalConstraints = await constraint("externalTokenDecreaseApproval");
+       try {
+        await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+        assert(false,"externalTokenDecreaseApproval should fail due to the global constraint ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
+       await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
+       await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+       try {
+        await await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+        assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
+       }
+       catch(ex){
+         helpers.assertVMException(ex);
+       }
 
-                       it("globalConstraints externalTokenTransfer  add & remove", async () => {
-                          controller = await  setup();
-                          var globalConstraints = await constraint("externalTokenTransfer");
-                          var standardToken = await StandardTokenMock.new(avatar.address, 100);
-                          let balanceAvatar = await standardToken.balanceOf(avatar.address);
-                          assert.equal(balanceAvatar, 100);
-
-                          try {
-                           await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-                           assert(false,"externalTokenTransfer should fail due to the global constraint ");
-                          }
-                          catch(ex){
-                            helpers.assertVMException(ex);
-                          }
-                          await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                          var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                          assert.equal(globalConstraintsCount[0],0);
-                          assert.equal(globalConstraintsCount[1],0);
-                          var tx = await controller.externalTokenTransfer(standardToken.address,accounts[1],50,avatar.address);
-                          const log = await new Promise((resolve) => {
-                                      avatar.ExternalTokenTransfer({fromBlock: tx.blockNumber})
-                                          .get((err,events) => {
-                                                  resolve(events);
-                                          });
-                                      });
-                          assert.equal(log[0].event,"ExternalTokenTransfer");
-                          balanceAvatar = await standardToken.balanceOf(avatar.address);
-                          assert.equal(balanceAvatar, 50);
-                          let balance1 = await standardToken.balanceOf(accounts[1]);
-                          assert.equal(balance1, 50);
-                          });
-
-                          it("globalConstraints externalTokenTransferFrom , externalTokenIncreaseApproval , externalTokenDecreaseApproval", async () => {
-                             var tx;
-                             var to   = accounts[1];
-                             controller = await  setup();
-                             var globalConstraints = await constraint("externalTokenIncreaseApproval");
-                             var standardToken = await StandardTokenMock.new(avatar.address, 100);
-                             try {
-                              await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-                              assert(false,"externalTokenIncreaseApproval should fail due to the global constraint ");
-                             }
-                             catch(ex){
-                               helpers.assertVMException(ex);
-                             }
-                             await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                             var globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                             assert.equal(globalConstraintsCount[0],0);
-                             assert.equal(globalConstraintsCount[1],0);
-
-                             tx = await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-                             var log = await new Promise((resolve) => {
-                                         avatar.ExternalTokenIncreaseApproval({fromBlock: tx.blockNumber})
-                                             .get((err,events) => {
-                                                     resolve(events);
-                                             });
-                                         });
-                             assert.equal(log[0].event,"ExternalTokenIncreaseApproval");
-                             globalConstraints = await constraint("externalTokenTransferFrom");
-                             try {
-                              await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-                              assert(false,"externalTokenTransferFrom should fail due to the global constraint ");
-                             }
-                             catch(ex){
-                               helpers.assertVMException(ex);
-                             }
-                             await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                             globalConstraintsCount =await controller.globalConstraintsCount(avatar.address);
-                             assert.equal(globalConstraintsCount[0],0);
-
-                             globalConstraints = await constraint("externalTokenDecreaseApproval");
-                             try {
-                              await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-                              assert(false,"externalTokenDecreaseApproval should fail due to the global constraint ");
-                             }
-                             catch(ex){
-                               helpers.assertVMException(ex);
-                             }
-                             await controller.removeGlobalConstraint(globalConstraints.address,avatar.address);
-                             await controller.externalTokenDecreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-                             try {
-                              await await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-                              assert(false,"externalTokenTransferFrom should fail due to decrease approval ");
-                             }
-                             catch(ex){
-                               helpers.assertVMException(ex);
-                             }
-
-                             await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
-                             tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
-                             log = await new Promise((resolve) => {
-                                         avatar.ExternalTokenTransferFrom({fromBlock: tx.blockNumber})
-                                             .get((err,events) => {
-                                                     resolve(events);
-                                             });
-                                         });
-                             assert.equal(log[0].event,"ExternalTokenTransferFrom");
-                             let balanceAvatar = await standardToken.balanceOf(avatar.address);
-                             assert.equal(balanceAvatar, 50);
-                             let balanceTo = await standardToken.balanceOf(to);
-                             assert.equal(balanceTo, 50);
-                             });
-
-
-
+       await controller.externalTokenIncreaseApproval(standardToken.address,avatar.address,50,avatar.address);
+       tx = await controller.externalTokenTransferFrom(standardToken.address,avatar.address,to,50,avatar.address);
+       await avatar.getPastEvents('ExternalTokenTransferFrom', {
+             filter: {_addr: avatar.address}, // Using an array means OR: e.g. 20 or 23
+             fromBlock: tx.blockNumber,
+             toBlock: 'latest'
+         })
+         .then(function(events){
+             assert.equal(events[0].event,"ExternalTokenTransferFrom");
+         });
+       let balanceAvatar = await standardToken.balanceOf(avatar.address);
+       assert.equal(balanceAvatar, 50);
+       let balanceTo = await standardToken.balanceOf(to);
+       assert.equal(balanceTo, 50);
+       });
 });

--- a/test/vestingscheme.js
+++ b/test/vestingscheme.js
@@ -34,18 +34,18 @@ const setup = async function (accounts) {
    testSetup.vestingSchemeParams= await setupVestingSchemeParams(testSetup.vestingScheme);
    //give some tokens to organization avatar so it could register the universal scheme.
    await testSetup.standardTokenMock.transfer(testSetup.org.avatar.address,30,{from:accounts[1]});
-   var permissions = "0x000000001";
+   var permissions = "0x00000001";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.vestingScheme.address],[testSetup.vestingSchemeParams.paramsHash],[permissions]);
 
    return testSetup;
 };
 
-contract('VestingScheme', function(accounts) {
+contract('VestingScheme', accounts => {
   before(function() {
-    helpers.etherForEveryone();
+    helpers.etherForEveryone(accounts);
   });
 
-   it("setParameters", async function() {
+   it("setParameters", async() =>{
      var vestingScheme = await VestingScheme.new();
      var absoluteVote = await AbsoluteVote.new();
      await vestingScheme.setParameters("0x1234",absoluteVote.address);
@@ -54,18 +54,22 @@ contract('VestingScheme', function(accounts) {
      assert.equal(parameters[1],absoluteVote.address);
      });
 
-     it("proposeVestingAgreement log", async function() {
+     it("proposeVestingAgreement log", async() => {
        var testSetup = await setup(accounts);
+       var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+
+       var signatures = [accounts[0],accounts[1],accounts[2]];
 
        var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
                                                                       accounts[1],
-                                                                      web3.eth.blockNumber,
+                                                                      blockNumber,
                                                                      15,
                                                                      2,
                                                                      3,
                                                                      11,
                                                                      3,
-                                                                     [accounts[0],accounts[1],accounts[2]],
+                                                                     signatures,
                                                                      testSetup.org.avatar.address);
        assert.equal(tx.logs.length, 1);
        assert.equal(tx.logs[0].event, "AgreementProposal");
@@ -73,182 +77,185 @@ contract('VestingScheme', function(accounts) {
        assert.equal(avatarAddress,testSetup.org.avatar.address);
       });
 
-       it("proposeVestingAgreement check owner vote", async function() {
-         var testSetup = await setup(accounts);
+    it("proposeVestingAgreement check owner vote", async function() {
+     var testSetup = await setup(accounts);
+     var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+     var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                    accounts[1],
+                                                                    blockNumber,
+                                                                    15,
+                                                                    2,
+                                                                    3,
+                                                                    11,
+                                                                    3,
+                                                                    [accounts[0],accounts[1],accounts[2]],
+                                                                    testSetup.org.avatar.address);
+     var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+     await helpers.checkVoteInfo(testSetup.vestingSchemeParams.votingMachine.absoluteVote,proposalId,accounts[0],[1,testSetup.reputationArray[0]]);
+    });
 
-         var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                        accounts[1],
-                                                                        web3.eth.blockNumber,
-                                                                        15,
-                                                                        2,
-                                                                        3,
-                                                                        11,
-                                                                        3,
-                                                                        [accounts[0],accounts[1],accounts[2]],
-                                                                        testSetup.org.avatar.address);
-         var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-         await helpers.checkVoteInfo(testSetup.vestingSchemeParams.votingMachine.absoluteVote,proposalId,accounts[0],[1,testSetup.reputationArray[0]]);
-        });
+    it("proposeVestingAgreement check assert _signaturesReqToCancel <= _signersArray.length", async function() {
+      var testSetup = await setup(accounts);
+      var _signaturesReqToCancel = 5;
+      var _signersArray = [];
+      for (var i=0;i<_signaturesReqToCancel-1;i++){
+        _signersArray[i] = accounts[i];
+      }
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-        it("proposeVestingAgreement check assert _signaturesReqToCancel <= _signersArray.length", async function() {
-          var testSetup = await setup(accounts);
-          var _signaturesReqToCancel = 5;
-          var _signersArray = [];
-          for (var i=0;i<_signaturesReqToCancel-1;i++){
-            _signersArray[i] = accounts[i];
-          }
+      try {
+       await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     15,
+                                                                     2,
+                                                                     3,
+                                                                     11,
+                                                                     _signaturesReqToCancel,
+                                                                     _signersArray,
+                                                                     testSetup.org.avatar.address);
+       assert(false,"proposeVestingAgreement should fail - due to _signaturesReqToCancel > _signersArray.length !");
+      }catch(ex){
+       helpers.assertVMException(ex);
+      }
+     });
 
+    it("proposeVestingAgreement check assert _numOfAgreedPeriods > 0", async function() {
+      var testSetup = await setup(accounts);
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-          try {
-           await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                         accounts[1],
-                                                                         web3.eth.blockNumber,
-                                                                         15,
-                                                                         2,
-                                                                         3,
-                                                                         11,
-                                                                         _signaturesReqToCancel,
-                                                                         _signersArray,
-                                                                         testSetup.org.avatar.address);
-           assert(false,"proposeVestingAgreement should fail - due to _signaturesReqToCancel > _signersArray.length !");
-          }catch(ex){
-           helpers.assertVMException(ex);
-          }
-         });
+      try {
+        await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+          accounts[1],
+          blockNumber,
+          15,
+          2,
+          0,
+          11,
+          3, [accounts[0], accounts[1], accounts[2]],
+          testSetup.org.avatar.address);
+        assert(false, "proposeVestingAgreement should fail - due to _numOfAgreedPeriods > 0 !");
+      } catch (ex) {
+        helpers.assertVMException(ex);
+      }
+    });
 
-        it("proposeVestingAgreement check assert _numOfAgreedPeriods > 0", async function() {
-          var testSetup = await setup(accounts);
+    it("execute proposeVestingAgreement- ProposedVestedAgreement supplies proposalId ", async function() {
+     var testSetup = await setup(accounts);
 
-          try {
-            await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-              accounts[1],
-              web3.eth.blockNumber,
-              15,
-              2,
-              0,
-              11,
-              3, [accounts[0], accounts[1], accounts[2]],
-              testSetup.org.avatar.address);
-            assert(false, "proposeVestingAgreement should fail - due to _numOfAgreedPeriods > 0 !");
-          } catch (ex) {
-            helpers.assertVMException(ex);
-          }
-        });
+     var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-           it("execute proposeVestingAgreement- ProposedVestedAgreement supplies proposalId ", async function() {
-             var testSetup = await setup(accounts);
+     var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                    accounts[1],
+                                                                    blockNumber,
+                                                                    15,
+                                                                    2,
+                                                                    3,
+                                                                    11,
+                                                                    0,
+                                                                    [],
+                                                                    testSetup.org.avatar.address);
+    //Vote with reputation to trigger execution
+     var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+     await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
+     await testSetup.vestingScheme.getPastEvents('ProposedVestedAgreement', {
+           filter: {_proposalId: proposalId},
+           fromBlock: tx.blockNumber,
+           toBlock: 'latest'
+       })
+       .then(function(events){
+           assert.equal(events[0].event,"ProposedVestedAgreement");
+       });
+    });
 
+     it("execute proposeVestingAgreement controller -yes - proposal data delete", async function() {
+       var testSetup = await setup(accounts);
 
-             var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                            accounts[1],
-                                                                            web3.eth.blockNumber,
-                                                                            15,
-                                                                            2,
-                                                                            3,
-                                                                            11,
-                                                                            0,
-                                                                            [],
-                                                                            testSetup.org.avatar.address);
-            //Vote with reputation to trigger execution
-             var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-             await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
-            const found = await new Promise((resolve) => {
-                testSetup.vestingScheme.ProposedVestedAgreement({_proposalId: proposalId}, {fromBlock: tx.blockNumber})
-                    .get((err,events) => {
-                        if (events.length === 1) {
-                            resolve(events[0].args._proposalId === proposalId);
-                        } else {
-                            resolve(false);
-                        }
-                    });
-                });
-                assert(found, "ProposedVestedAgreement did not supply the proposalId");
-            });
+       var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-           it("execute proposeVestingAgreement controller -yes - proposal data delete", async function() {
-             var testSetup = await setup(accounts);
+       var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                      accounts[1],
+                                                                      blockNumber,
+                                                                      15,
+                                                                      2,
+                                                                      3,
+                                                                      11,
+                                                                      0,
+                                                                      [],
+                                                                      testSetup.org.avatar.address);
+      //Vote with reputation to trigger execution
+       var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+       //check organizationsProposals before execution
+       var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
+       assert.equal(organizationProposal[0],testSetup.org.token.address);//proposalType
+       await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
+       //check organizationsProposals after execution
+       organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
+       assert.equal(organizationProposal[0],0x0000000000000000000000000000000000000000);//new contract address
+      });
 
+    it("execute proposeVestingAgreement  -from none voting contact -should fail", async function() {
+      var testSetup = await setup(accounts);
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-             var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                            accounts[1],
-                                                                            web3.eth.blockNumber,
-                                                                            15,
-                                                                            2,
-                                                                            3,
-                                                                            11,
-                                                                            0,
-                                                                            [],
-                                                                            testSetup.org.avatar.address);
-            //Vote with reputation to trigger execution
-             var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-             //check organizationsProposals before execution
-             var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
-             assert.equal(organizationProposal[0],testSetup.org.token.address);//proposalType
-             await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,1,0,{from:accounts[2]});
-             //check organizationsProposals after execution
-             organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
-             assert.equal(organizationProposal[0],0x0000000000000000000000000000000000000000);//new contract address
-            });
+      var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     15,
+                                                                     2,
+                                                                     3,
+                                                                     11,
+                                                                     0,
+                                                                     [],
+                                                                     testSetup.org.avatar.address);
+      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+      //check organizationsProposals before execution
+      var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
+      assert.equal(organizationProposal[0],testSetup.org.token.address);
+      try{
+        await testSetup.vestingScheme.executeProposal(proposalId,0);
+        assert(false,"execute should fail - due because it is not called from voting contract !");
+       }catch(ex){
+        helpers.assertVMException(ex);
+       }
+     });
 
-            it("execute proposeVestingAgreement  -from none voting contact -should fail", async function() {
-              var testSetup = await setup(accounts);
+    it("executeProposeVestingAgreement - no decision  - proposal data delete", async function() {
+      var testSetup = await setup(accounts);
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-              var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                             accounts[1],
-                                                                             web3.eth.blockNumber,
-                                                                             15,
-                                                                             2,
-                                                                             3,
-                                                                             11,
-                                                                             0,
-                                                                             [],
-                                                                             testSetup.org.avatar.address);
-              var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-              //check organizationsProposals before execution
-              var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
-              assert.equal(organizationProposal[0],testSetup.org.token.address);
-              try{
-              await testSetup.vestingScheme.executeProposal(proposalId,0);
-              assert(false,"execute should fail - due because it is not called from voting contract !");
-               }catch(ex){
-                helpers.assertVMException(ex);
-               }
-             });
+      var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     15,
+                                                                     2,
+                                                                     3,
+                                                                     11,
+                                                                     0,
+                                                                     [],
+                                                                     testSetup.org.avatar.address);
+      var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
+      //check organizationsProposals before execution
+      var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
+      assert.equal(organizationProposal[0],testSetup.org.token.address);
 
-            it("executeProposeVestingAgreement - no decision  - proposal data delete", async function() {
-              var testSetup = await setup(accounts);
-
-              var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
-                                                                             accounts[1],
-                                                                             web3.eth.blockNumber,
-                                                                             15,
-                                                                             2,
-                                                                             3,
-                                                                             11,
-                                                                             0,
-                                                                             [],
-                                                                             testSetup.org.avatar.address);
-              var proposalId = await helpers.getValueFromLogs(tx, '_proposalId',1);
-              //check organizationsProposals before execution
-              var organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
-              assert.equal(organizationProposal[0],testSetup.org.token.address);
-
-              //Vote with reputation to trigger execution
-              await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,0,0,{from:accounts[2]});
-              //check organizationsProposals after execution
-              organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
-              assert.equal(organizationProposal[0],0x0000000000000000000000000000000000000000);//new contract address
-             });
+      //Vote with reputation to trigger execution
+      await testSetup.vestingSchemeParams.votingMachine.absoluteVote.vote(proposalId,0,0,{from:accounts[2]});
+      //check organizationsProposals after execution
+      organizationProposal = await testSetup.vestingScheme.organizationsProposals(testSetup.org.avatar.address,proposalId);
+      assert.equal(organizationProposal[0],0x0000000000000000000000000000000000000000);//new contract address
+     });
 
              it("execute proposeVestingAgreement controller -yes - check minting", async function() {
                var testSetup = await setup(accounts);
                var amountPerPeriod =3;
                var numberOfAgreedPeriods = 7;
+               var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
 
                var tx = await testSetup.vestingScheme.proposeVestingAgreement(accounts[0],
                                                                               accounts[1],
-                                                                              web3.eth.blockNumber,
+                                                                              blockNumber,
                                                                               amountPerPeriod,
                                                                               2,
                                                                               numberOfAgreedPeriods,
@@ -269,643 +276,660 @@ contract('VestingScheme', function(accounts) {
                assert.equal(await testSetup.org.token.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
               });
 
-              it("createVestedAgreement check agreement id ", async function() {
-                var testSetup = await setup(accounts);
-                var amountPerPeriod =3;
-                var numberOfAgreedPeriods = 7;
+    it("createVestedAgreement check agreement id ", async function() {
+      var testSetup = await setup(accounts);
+      var amountPerPeriod =3;
+      var numberOfAgreedPeriods = 7;
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-                await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                               accounts[0],
-                                                                               accounts[1],
-                                                                               web3.eth.blockNumber,
-                                                                               amountPerPeriod,
-                                                                               2,
-                                                                               numberOfAgreedPeriods,
-                                                                               11,
-                                                                               0,
-                                                                               [],{from:accounts[1]});
-                assert.equal(tx.logs.length, 1);
-                assert.equal(tx.logs[0].event, "NewVestedAgreement");
-                var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                assert.equal(agreementId,0);
-                tx = await testSetup.vestingScheme.createVestedAgreement( testSetup.standardTokenMock.address,
+
+      await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+      var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                     accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     amountPerPeriod,
+                                                                     2,
+                                                                     numberOfAgreedPeriods,
+                                                                     11,
+                                                                     0,
+                                                                     [],{from:accounts[1]});
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "NewVestedAgreement");
+      var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+      assert.equal(agreementId,0);
+      blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+      tx = await testSetup.vestingScheme.createVestedAgreement( testSetup.standardTokenMock.address,
+                                                                accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     amountPerPeriod,
+                                                                     2,
+                                                                     numberOfAgreedPeriods,
+                                                                     11,
+                                                                     0,
+                                                                     [],
+                                                                     {from:accounts[1]});
+      assert.equal(tx.logs.length, 1);
+      assert.equal(tx.logs[0].event, "NewVestedAgreement");
+      agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+      assert.equal(agreementId,1);
+     });
+
+    it("createVestedAgreement check periodLength==0 ", async function() {
+      var testSetup = await setup(accounts);
+      var amountPerPeriod =3;
+      var numberOfAgreedPeriods = 7;
+      var periodLength = 0;
+
+      await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+      try{
+       await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                     accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     amountPerPeriod,
+                                                                     periodLength,
+                                                                     numberOfAgreedPeriods,
+                                                                     11,
+                                                                     0,
+                                                                     [],{from:accounts[1]});
+
+      assert(false,"createVestedAgreement should fail - due to periodLength == 0");
+      }catch(ex){
+       helpers.assertVMException(ex);
+      }
+     });
+
+     it("createVestedAgreement check payment", async function() {
+       var testSetup = await setup(accounts);
+       var amountPerPeriod =3;
+       var numberOfAgreedPeriods = 7;
+       var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+       await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                      accounts[0],
+                                                                      accounts[1],
+                                                                      blockNumber,
+                                                                      amountPerPeriod,
+                                                                      2,
+                                                                      numberOfAgreedPeriods,
+                                                                      11,
+                                                                      0,
+                                                                      [],{from:accounts[1]});
+       assert.equal(await testSetup.standardTokenMock.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
+      });
+
+      it("createVestedAgreement check assert _signaturesReqToCancel <= _signersArray.length", async function() {
+        var testSetup = await setup(accounts);
+        var _signaturesReqToCancel = 5;
+        var amountPerPeriod =3;
+        var numberOfAgreedPeriods = 7;
+        var _signersArray = [];
+        for (var i=0;i<_signaturesReqToCancel-1;i++){
+          _signersArray[i] = accounts[i];
+        }
+
+        await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+        var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+        try {
+          await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                         accounts[0],
+                                                                         accounts[1],
+                                                                         blockNumber,
+                                                                         amountPerPeriod,
+                                                                         2,
+                                                                         numberOfAgreedPeriods,
+                                                                         11,
+                                                                         _signaturesReqToCancel,
+                                                                         _signersArray,{from:accounts[1]});
+         assert(false,"createVestedAgreement should fail - due to _signaturesReqToCancel > _signersArray.length !");
+        }catch(ex){
+         helpers.assertVMException(ex);
+        }
+       });
+
+    it("createVestedAgreement check _numOfAgreedPeriods > 0 ", async function() {
+      var testSetup = await setup(accounts);
+      var amountPerPeriod = 3;
+      var numberOfAgreedPeriods = 0;
+      var periodLength = 2;
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+      try {
+        await testSetup.vestingScheme.createVestedAgreement(testSetup.standardTokenMock.address,
+          accounts[0],
+          accounts[1],
+          blockNumber,
+          amountPerPeriod,
+          periodLength,
+          numberOfAgreedPeriods,
+          11,
+          0, [], {
+            from: accounts[1]
+          });
+
+        assert(false, "createVestedAgreement should fail - due to _numOfAgreedPeriods > 0");
+      } catch (ex) {
+        helpers.assertVMException(ex);
+      }
+    });
+
+   it("signToCancelAgreement log", async function() {
+     var testSetup = await setup(accounts);
+     var _signaturesReqToCancel = 5;
+     var amountPerPeriod =3;
+     var numberOfAgreedPeriods = 7;
+     var _signersArray = [];
+     for (var i=0;i<_signaturesReqToCancel;i++){
+       _signersArray[i] = accounts[i];
+     }
+     var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+     await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+     var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                    accounts[0],
+                                                                    accounts[1],
+                                                                    blockNumber,
+                                                                    amountPerPeriod,
+                                                                    2,
+                                                                    numberOfAgreedPeriods,
+                                                                    11,
+                                                                    _signaturesReqToCancel,
+                                                                    _signersArray,{from:accounts[1]});
+     var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+     assert.equal(agreementId,0);
+     tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+     assert.equal(tx.logs.length, 1);
+     assert.equal(tx.logs[0].event, "SignToCancelAgreement");
+    });
+
+    it("signToCancelAgreement from non signer", async function() {
+      var testSetup = await setup(accounts);
+      var _signaturesReqToCancel = 1;
+      var amountPerPeriod =3;
+      var numberOfAgreedPeriods = 7;
+      var _signersArray = [];
+      for (var i=0;i<_signaturesReqToCancel;i++){
+        _signersArray[i] = accounts[i];
+      }
+      var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+      await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+      var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                     accounts[0],
+                                                                     accounts[1],
+                                                                     blockNumber,
+                                                                     amountPerPeriod,
+                                                                     2,
+                                                                     numberOfAgreedPeriods,
+                                                                     11,
+                                                                     _signaturesReqToCancel,
+                                                                     _signersArray,{from:accounts[1]});
+      var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+      try{
+      await testSetup.vestingScheme.signToCancelAgreement(agreementId,{from: accounts[1]});
+      assert(false,"signToCancelAgreement should fail - due to accounts[1] is not authorized signer");
+      }catch(ex){
+        helpers.assertVMException(ex);
+      }
+     });
+
+     it("signToCancelAgreement wrong agreementId", async function() {
+       var testSetup = await setup(accounts);
+       var _signaturesReqToCancel = 1;
+       var amountPerPeriod =3;
+       var numberOfAgreedPeriods = 7;
+       var _signersArray = [];
+       for (var i=0;i<_signaturesReqToCancel;i++){
+         _signersArray[i] = accounts[i];
+       }
+
+       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+       var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+       var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                      accounts[0],
+                                                                      accounts[1],
+                                                                      blockNumber,
+                                                                      amountPerPeriod,
+                                                                      2,
+                                                                      numberOfAgreedPeriods,
+                                                                      11,
+                                                                      _signaturesReqToCancel,
+                                                                      _signersArray,{from:accounts[1]});
+       var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+       try{
+       await testSetup.vestingScheme.signToCancelAgreement(agreementId+1);
+       assert(false,"signToCancelAgreement should fail - due to wrong agreementId");
+       }catch(ex){
+         helpers.assertVMException(ex);
+       }
+      });
+
+      it("signToCancelAgreement double sign attempt", async function() {
+        var testSetup = await setup(accounts);
+        var _signaturesReqToCancel = 1;
+        var amountPerPeriod =3;
+        var numberOfAgreedPeriods = 7;
+        var _signersArray = [];
+        for (var i=0;i<_signaturesReqToCancel;i++){
+          _signersArray[i] = accounts[i];
+        }
+
+        await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+        var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+        var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                       accounts[0],
+                                                                       accounts[1],
+                                                                       blockNumber,
+                                                                       amountPerPeriod,
+                                                                       2,
+                                                                       numberOfAgreedPeriods,
+                                                                       11,
+                                                                       _signaturesReqToCancel,
+                                                                       _signersArray,{from:accounts[1]});
+        var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+        await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+        try{
+        await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+        assert(false,"signToCancelAgreement should fail - due to double sign attempt");
+        }catch(ex){
+          helpers.assertVMException(ex);
+        }
+       });
+
+     it("signToCancelAgreement check actual cancel", async function() {
+       var testSetup = await setup(accounts);
+       var returnOnCancelAddress = accounts[2];
+       var _signaturesReqToCancel = 2;
+       var amountPerPeriod =3;
+       var numberOfAgreedPeriods = 7;
+       var _signersArray = [];
+       for (var i=0;i<_signaturesReqToCancel;i++){
+         _signersArray[i] = accounts[i];
+       }
+
+       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+       var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+       var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                      accounts[0],
+                                                                      returnOnCancelAddress,
+                                                                      blockNumber,
+                                                                      amountPerPeriod,
+                                                                      2,
+                                                                      numberOfAgreedPeriods,
+                                                                      11,
+                                                                      _signaturesReqToCancel,
+                                                                      _signersArray,{from:accounts[1]});
+       var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+       tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+       var agreement = await testSetup.vestingScheme.agreements(agreementId);
+       assert.equal(agreement[10],1);
+       tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId,{from:accounts[1]});
+       assert.equal(tx.logs.length, 2);
+       assert.equal(tx.logs[1].event, "AgreementCancel");
+       //check agreement deleted
+       agreement = await testSetup.vestingScheme.agreements(agreementId);
+       assert.equal(agreement[0],0x0000000000000000000000000000000000000000);
+       assert.equal(agreement[1],0x0000000000000000000000000000000000000000);
+       assert.equal(agreement[10],0);
+       var balance = await testSetup.standardTokenMock.balanceOf(returnOnCancelAddress);
+       assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
+      });
+
+       it("revokeSignToCancelAgreement log", async function() {
+         var testSetup = await setup(accounts);
+         var _signaturesReqToCancel = 5;
+         var amountPerPeriod =3;
+         var numberOfAgreedPeriods = 7;
+         var _signersArray = [];
+         for (var i=0;i<_signaturesReqToCancel;i++){
+           _signersArray[i] = accounts[i];
+         }
+
+         await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+         var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+         var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                        accounts[0],
+                                                                        accounts[1],
+                                                                        blockNumber,
+                                                                        amountPerPeriod,
+                                                                        2,
+                                                                        numberOfAgreedPeriods,
+                                                                        11,
+                                                                        _signaturesReqToCancel,
+                                                                        _signersArray,{from:accounts[1]});
+         var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+         assert.equal(agreementId,0);
+         tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+         var agreement = await testSetup.vestingScheme.agreements(agreementId);
+         assert.equal(agreement[10],1);//signaturesReceivedCounter
+
+         assert.equal(tx.logs.length, 1);
+         assert.equal(tx.logs[0].event, "SignToCancelAgreement");
+         tx = await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId);
+         assert.equal(tx.logs.length, 1);
+         assert.equal(tx.logs[0].event, "RevokeSignToCancelAgreement");
+         agreement = await testSetup.vestingScheme.agreements(agreementId);
+         assert.equal(agreement[10],0);//signaturesReceivedCounter
+
+        });
+
+        it("revokeSignToCancelAgreement from non signer", async function() {
+          var testSetup = await setup(accounts);
+          var _signaturesReqToCancel = 2;
+          var amountPerPeriod =3;
+          var numberOfAgreedPeriods = 7;
+          var _signersArray = [];
+          for (var i=0;i<_signaturesReqToCancel;i++){
+            _signersArray[i] = accounts[i];
+          }
+
+          await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+          var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+          var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                         accounts[0],
+                                                                         accounts[1],
+                                                                         blockNumber,
+                                                                         amountPerPeriod,
+                                                                         2,
+                                                                         numberOfAgreedPeriods,
+                                                                         11,
+                                                                         _signaturesReqToCancel,
+                                                                         _signersArray,{from:accounts[1]});
+          var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+          assert.equal(agreementId,0);
+          tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+          assert.equal(tx.logs.length, 1);
+          assert.equal(tx.logs[0].event, "SignToCancelAgreement");
+          try{
+          await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId,{from:accounts[2]});
+          assert(false,"revokeSignToCancelAgreement should fail - due to accounts[2] is not authorized signer");
+          }catch(ex){
+            helpers.assertVMException(ex);
+          }
+         });
+
+         it("revokeSignToCancelAgreement wrong agreementId", async function() {
+           var testSetup = await setup(accounts);
+           var _signaturesReqToCancel = 2;
+           var amountPerPeriod =3;
+           var numberOfAgreedPeriods = 7;
+           var _signersArray = [];
+           for (var i=0;i<_signaturesReqToCancel;i++){
+             _signersArray[i] = accounts[i];
+           }
+
+           await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+           var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+
+           var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
                                                                           accounts[0],
-                                                                               accounts[1],
-                                                                               web3.eth.blockNumber,
-                                                                               amountPerPeriod,
-                                                                               2,
-                                                                               numberOfAgreedPeriods,
-                                                                               11,
-                                                                               0,
-                                                                               [],
-                                                                               {from:accounts[1]});
-                assert.equal(tx.logs.length, 1);
-                assert.equal(tx.logs[0].event, "NewVestedAgreement");
-                agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                assert.equal(agreementId,1);
-               });
+                                                                          accounts[1],
+                                                                          blockNumber,
+                                                                          amountPerPeriod,
+                                                                          2,
+                                                                          numberOfAgreedPeriods,
+                                                                          11,
+                                                                          _signaturesReqToCancel,
+                                                                          _signersArray,{from:accounts[1]});
+           var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+           assert.equal(agreementId,0);
+           tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
+           assert.equal(tx.logs.length, 1);
+           assert.equal(tx.logs[0].event, "SignToCancelAgreement");
 
-              it("createVestedAgreement check periodLength==0 ", async function() {
-                var testSetup = await setup(accounts);
-                var amountPerPeriod =3;
-                var numberOfAgreedPeriods = 7;
-                var periodLength = 0;
+           try{
+           await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId+1);
+           assert(false,"revokeSignToCancelAgreement should fail - due to wrong agreement id");
+           }catch(ex){
+             helpers.assertVMException(ex);
+           }
+          });
 
-                await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                try{
-                 await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                               accounts[0],
-                                                                               accounts[1],
-                                                                               web3.eth.blockNumber,
-                                                                               amountPerPeriod,
-                                                                               periodLength,
-                                                                               numberOfAgreedPeriods,
-                                                                               11,
-                                                                               0,
-                                                                               [],{from:accounts[1]});
+          it("revokeSignToCancelAgreement without signing before", async function() {
+            var testSetup = await setup(accounts);
+            var _signaturesReqToCancel = 2;
+            var amountPerPeriod =3;
+            var numberOfAgreedPeriods = 7;
+            var _signersArray = [];
+            for (var i=0;i<_signaturesReqToCancel;i++){
+              _signersArray[i] = accounts[i];
+            }
 
-                assert(false,"createVestedAgreement should fail - due to periodLength == 0");
-                }catch(ex){
-                 helpers.assertVMException(ex);
-                }
-               });
+            await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+            var blockNumber = await (web3.utils.toBN(await web3.eth.getBlockNumber()));
 
-               it("createVestedAgreement check payment", async function() {
-                 var testSetup = await setup(accounts);
-                 var amountPerPeriod =3;
-                 var numberOfAgreedPeriods = 7;
+            var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                           accounts[0],
+                                                                           accounts[1],
+                                                                           blockNumber,
+                                                                           amountPerPeriod,
+                                                                           2,
+                                                                           numberOfAgreedPeriods,
+                                                                           11,
+                                                                           _signaturesReqToCancel,
+                                                                           _signersArray,{from:accounts[1]});
+            var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+            assert.equal(agreementId,0);
 
-                 await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                 await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                accounts[0],
-                                                                                accounts[1],
-                                                                                web3.eth.blockNumber,
-                                                                                amountPerPeriod,
-                                                                                2,
-                                                                                numberOfAgreedPeriods,
-                                                                                11,
-                                                                                0,
-                                                                                [],{from:accounts[1]});
-                 assert.equal(await testSetup.standardTokenMock.balanceOf(testSetup.vestingScheme.address),amountPerPeriod*numberOfAgreedPeriods);
-                });
+            try{
+            await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId);
+            assert(false,"revokeSignToCancelAgreement should fail - accounts[0] did not signed.");
+            }catch(ex){
+              helpers.assertVMException(ex);
+            }
+           });
 
-                it("createVestedAgreement check assert _signaturesReqToCancel <= _signersArray.length", async function() {
-                  var testSetup = await setup(accounts);
-                  var _signaturesReqToCancel = 5;
-                  var amountPerPeriod =3;
-                  var numberOfAgreedPeriods = 7;
-                  var _signersArray = [];
-                  for (var i=0;i<_signaturesReqToCancel-1;i++){
-                    _signersArray[i] = accounts[i];
-                  }
+     it("collect log periodsFromStartingBlock < agreement.numOfAgreedPeriods", async function() {
+       var testSetup = await setup(accounts);
+       var beneficiary = accounts[2];
+       var _signaturesReqToCancel = 5;
+       var amountPerPeriod =3;
+       var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+       var numberOfAgreedPeriods = 7;
+       var _signersArray = [];
+       var periodLength = 1;
+       var cliffInPeriods = 0;
+       for (var i=0;i<_signaturesReqToCancel;i++){
+         _signersArray[i] = accounts[i];
+       }
 
-                  await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                  try {
-                    await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                   accounts[0],
-                                                                                   accounts[1],
-                                                                                   web3.eth.blockNumber,
-                                                                                   amountPerPeriod,
-                                                                                   2,
-                                                                                   numberOfAgreedPeriods,
-                                                                                   11,
-                                                                                   _signaturesReqToCancel,
-                                                                                   _signersArray,{from:accounts[1]});
-                   assert(false,"createVestedAgreement should fail - due to _signaturesReqToCancel > _signersArray.length !");
-                  }catch(ex){
-                   helpers.assertVMException(ex);
-                  }
-                 });
+       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+       var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                      beneficiary,
+                                                                      accounts[1],
+                                                                      startingBlock,
+                                                                      amountPerPeriod,
+                                                                      periodLength,
+                                                                      numberOfAgreedPeriods,
+                                                                      cliffInPeriods,
+                                                                      _signaturesReqToCancel,
+                                                                      _signersArray,{from:accounts[1]});
+       var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+       tx = await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
+       assert.equal(tx.logs.length, 1);
+       assert.equal(tx.logs[0].event, "Collect");
+       var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
+       var periodsFromStartingBlock = Math.floor((await web3.eth.getBlockNumber()-startingBlock)/(periodLength));
+       assert.equal(balance.toNumber(),periodsFromStartingBlock*amountPerPeriod);
+      });
 
-                  it("createVestedAgreement check _numOfAgreedPeriods > 0 ", async function() {
-                    var testSetup = await setup(accounts);
-                    var amountPerPeriod = 3;
-                    var numberOfAgreedPeriods = 0;
-                    var periodLength = 2;
+      it("collect log periodsFromStartingBlock >= agreement.numOfAgreedPeriods", async function() {
+        var testSetup = await setup(accounts);
+        var beneficiary = accounts[2];
+        var _signaturesReqToCancel = 5;
+        var amountPerPeriod =3;
+        var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+        var numberOfAgreedPeriods = 2;
+        var _signersArray = [];
+        var periodLength = 1;
+        var cliffInPeriods = 0;
+        for (var i=0;i<_signaturesReqToCancel;i++){
+          _signersArray[i] = accounts[i];
+        }
 
-                    try {
-                      await testSetup.vestingScheme.createVestedAgreement(testSetup.standardTokenMock.address,
-                        accounts[0],
-                        accounts[1],
-                        web3.eth.blockNumber,
-                        amountPerPeriod,
-                        periodLength,
-                        numberOfAgreedPeriods,
-                        11,
-                        0, [], {
-                          from: accounts[1]
-                        });
-
-                      assert(false, "createVestedAgreement should fail - due to _numOfAgreedPeriods > 0");
-                    } catch (ex) {
-                      helpers.assertVMException(ex);
-                    }
-                  });
-
-                 it("signToCancelAgreement log", async function() {
-                   var testSetup = await setup(accounts);
-                   var _signaturesReqToCancel = 5;
-                   var amountPerPeriod =3;
-                   var numberOfAgreedPeriods = 7;
-                   var _signersArray = [];
-                   for (var i=0;i<_signaturesReqToCancel;i++){
-                     _signersArray[i] = accounts[i];
-                   }
-
-                   await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                   var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                  accounts[0],
-                                                                                  accounts[1],
-                                                                                  web3.eth.blockNumber,
-                                                                                  amountPerPeriod,
-                                                                                  2,
-                                                                                  numberOfAgreedPeriods,
-                                                                                  11,
-                                                                                  _signaturesReqToCancel,
-                                                                                  _signersArray,{from:accounts[1]});
-                   var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                   assert.equal(agreementId,0);
-                   tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                   assert.equal(tx.logs.length, 1);
-                   assert.equal(tx.logs[0].event, "SignToCancelAgreement");
-                  });
-
-                  it("signToCancelAgreement from non signer", async function() {
-                    var testSetup = await setup(accounts);
-                    var _signaturesReqToCancel = 1;
-                    var amountPerPeriod =3;
-                    var numberOfAgreedPeriods = 7;
-                    var _signersArray = [];
-                    for (var i=0;i<_signaturesReqToCancel;i++){
-                      _signersArray[i] = accounts[i];
-                    }
-
-                    await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                    var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                   accounts[0],
-                                                                                   accounts[1],
-                                                                                   web3.eth.blockNumber,
-                                                                                   amountPerPeriod,
-                                                                                   2,
-                                                                                   numberOfAgreedPeriods,
-                                                                                   11,
-                                                                                   _signaturesReqToCancel,
-                                                                                   _signersArray,{from:accounts[1]});
-                    var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                    try{
-                    await testSetup.vestingScheme.signToCancelAgreement(agreementId,{from: accounts[1]});
-                    assert(false,"signToCancelAgreement should fail - due to accounts[1] is not authorized signer");
-                    }catch(ex){
-                      helpers.assertVMException(ex);
-                    }
-                   });
-
-                   it("signToCancelAgreement wrong agreementId", async function() {
-                     var testSetup = await setup(accounts);
-                     var _signaturesReqToCancel = 1;
-                     var amountPerPeriod =3;
-                     var numberOfAgreedPeriods = 7;
-                     var _signersArray = [];
-                     for (var i=0;i<_signaturesReqToCancel;i++){
-                       _signersArray[i] = accounts[i];
-                     }
-
-                     await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                     var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                    accounts[0],
-                                                                                    accounts[1],
-                                                                                    web3.eth.blockNumber,
-                                                                                    amountPerPeriod,
-                                                                                    2,
-                                                                                    numberOfAgreedPeriods,
-                                                                                    11,
-                                                                                    _signaturesReqToCancel,
-                                                                                    _signersArray,{from:accounts[1]});
-                     var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                     try{
-                     await testSetup.vestingScheme.signToCancelAgreement(agreementId+1);
-                     assert(false,"signToCancelAgreement should fail - due to wrong agreementId");
-                     }catch(ex){
-                       helpers.assertVMException(ex);
-                     }
-                    });
-
-                    it("signToCancelAgreement double sign attempt", async function() {
-                      var testSetup = await setup(accounts);
-                      var _signaturesReqToCancel = 1;
-                      var amountPerPeriod =3;
-                      var numberOfAgreedPeriods = 7;
-                      var _signersArray = [];
-                      for (var i=0;i<_signaturesReqToCancel;i++){
-                        _signersArray[i] = accounts[i];
-                      }
-
-                      await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                      var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                     accounts[0],
-                                                                                     accounts[1],
-                                                                                     web3.eth.blockNumber,
-                                                                                     amountPerPeriod,
-                                                                                     2,
-                                                                                     numberOfAgreedPeriods,
-                                                                                     11,
-                                                                                     _signaturesReqToCancel,
-                                                                                     _signersArray,{from:accounts[1]});
-                      var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                      await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                      try{
-                      await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                      assert(false,"signToCancelAgreement should fail - due to double sign attempt");
-                      }catch(ex){
-                        helpers.assertVMException(ex);
-                      }
-                     });
-
-                     it("signToCancelAgreement check actual cancel", async function() {
-                       var testSetup = await setup(accounts);
-                       var returnOnCancelAddress = accounts[2];
-                       var _signaturesReqToCancel = 2;
-                       var amountPerPeriod =3;
-                       var numberOfAgreedPeriods = 7;
-                       var _signersArray = [];
-                       for (var i=0;i<_signaturesReqToCancel;i++){
-                         _signersArray[i] = accounts[i];
-                       }
-
-                       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                       var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                      accounts[0],
-                                                                                      returnOnCancelAddress,
-                                                                                      web3.eth.blockNumber,
-                                                                                      amountPerPeriod,
-                                                                                      2,
-                                                                                      numberOfAgreedPeriods,
-                                                                                      11,
-                                                                                      _signaturesReqToCancel,
-                                                                                      _signersArray,{from:accounts[1]});
-                       var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                       tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                       var agreement = await testSetup.vestingScheme.agreements(agreementId);
-                       assert.equal(agreement[10],1);
-                       tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId,{from:accounts[1]});
-                       assert.equal(tx.logs.length, 2);
-                       assert.equal(tx.logs[1].event, "AgreementCancel");
-                       //check agreement deleted
-                       agreement = await testSetup.vestingScheme.agreements(agreementId);
-                       assert.equal(agreement[0],0x0000000000000000000000000000000000000000);
-                       assert.equal(agreement[1],0x0000000000000000000000000000000000000000);
-                       assert.equal(agreement[10],0);
-                       var balance = await testSetup.standardTokenMock.balanceOf(returnOnCancelAddress);
-                       assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
-                      });
-
-                       it("revokeSignToCancelAgreement log", async function() {
-                         var testSetup = await setup(accounts);
-                         var _signaturesReqToCancel = 5;
-                         var amountPerPeriod =3;
-                         var numberOfAgreedPeriods = 7;
-                         var _signersArray = [];
-                         for (var i=0;i<_signaturesReqToCancel;i++){
-                           _signersArray[i] = accounts[i];
-                         }
-
-                         await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                         var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                        accounts[0],
-                                                                                        accounts[1],
-                                                                                        web3.eth.blockNumber,
-                                                                                        amountPerPeriod,
-                                                                                        2,
-                                                                                        numberOfAgreedPeriods,
-                                                                                        11,
-                                                                                        _signaturesReqToCancel,
-                                                                                        _signersArray,{from:accounts[1]});
-                         var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                         assert.equal(agreementId,0);
-                         tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                         var agreement = await testSetup.vestingScheme.agreements(agreementId);
-                         assert.equal(agreement[10],1);//signaturesReceivedCounter
-
-                         assert.equal(tx.logs.length, 1);
-                         assert.equal(tx.logs[0].event, "SignToCancelAgreement");
-                         tx = await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId);
-                         assert.equal(tx.logs.length, 1);
-                         assert.equal(tx.logs[0].event, "RevokeSignToCancelAgreement");
-                         agreement = await testSetup.vestingScheme.agreements(agreementId);
-                         assert.equal(agreement[10],0);//signaturesReceivedCounter
-
-                        });
-
-                        it("revokeSignToCancelAgreement from non signer", async function() {
-                          var testSetup = await setup(accounts);
-                          var _signaturesReqToCancel = 2;
-                          var amountPerPeriod =3;
-                          var numberOfAgreedPeriods = 7;
-                          var _signersArray = [];
-                          for (var i=0;i<_signaturesReqToCancel;i++){
-                            _signersArray[i] = accounts[i];
-                          }
-
-                          await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                          var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                         accounts[0],
-                                                                                         accounts[1],
-                                                                                         web3.eth.blockNumber,
-                                                                                         amountPerPeriod,
-                                                                                         2,
-                                                                                         numberOfAgreedPeriods,
-                                                                                         11,
-                                                                                         _signaturesReqToCancel,
-                                                                                         _signersArray,{from:accounts[1]});
-                          var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                          assert.equal(agreementId,0);
-                          tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                          assert.equal(tx.logs.length, 1);
-                          assert.equal(tx.logs[0].event, "SignToCancelAgreement");
-                          try{
-                          await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId,{from:accounts[2]});
-                          assert(false,"revokeSignToCancelAgreement should fail - due to accounts[2] is not authorized signer");
-                          }catch(ex){
-                            helpers.assertVMException(ex);
-                          }
-                         });
-
-                         it("revokeSignToCancelAgreement wrong agreementId", async function() {
-                           var testSetup = await setup(accounts);
-                           var _signaturesReqToCancel = 2;
-                           var amountPerPeriod =3;
-                           var numberOfAgreedPeriods = 7;
-                           var _signersArray = [];
-                           for (var i=0;i<_signaturesReqToCancel;i++){
-                             _signersArray[i] = accounts[i];
-                           }
-
-                           await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                           var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                          accounts[0],
-                                                                                          accounts[1],
-                                                                                          web3.eth.blockNumber,
-                                                                                          amountPerPeriod,
-                                                                                          2,
-                                                                                          numberOfAgreedPeriods,
-                                                                                          11,
-                                                                                          _signaturesReqToCancel,
-                                                                                          _signersArray,{from:accounts[1]});
-                           var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                           assert.equal(agreementId,0);
-                           tx = await testSetup.vestingScheme.signToCancelAgreement(agreementId);
-                           assert.equal(tx.logs.length, 1);
-                           assert.equal(tx.logs[0].event, "SignToCancelAgreement");
-
-                           try{
-                           await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId+1);
-                           assert(false,"revokeSignToCancelAgreement should fail - due to wrong agreement id");
-                           }catch(ex){
-                             helpers.assertVMException(ex);
-                           }
-                          });
-
-                          it("revokeSignToCancelAgreement without signing before", async function() {
-                            var testSetup = await setup(accounts);
-                            var _signaturesReqToCancel = 2;
-                            var amountPerPeriod =3;
-                            var numberOfAgreedPeriods = 7;
-                            var _signersArray = [];
-                            for (var i=0;i<_signaturesReqToCancel;i++){
-                              _signersArray[i] = accounts[i];
-                            }
-
-                            await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                            var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                           accounts[0],
-                                                                                           accounts[1],
-                                                                                           web3.eth.blockNumber,
-                                                                                           amountPerPeriod,
-                                                                                           2,
-                                                                                           numberOfAgreedPeriods,
-                                                                                           11,
-                                                                                           _signaturesReqToCancel,
-                                                                                           _signersArray,{from:accounts[1]});
-                            var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                            assert.equal(agreementId,0);
-
-                            try{
-                            await testSetup.vestingScheme.revokeSignToCancelAgreement(agreementId);
-                            assert(false,"revokeSignToCancelAgreement should fail - accounts[0] did not signed.");
-                            }catch(ex){
-                              helpers.assertVMException(ex);
-                            }
-                           });
-
-                           it("collect log periodsFromStartingBlock < agreement.numOfAgreedPeriods", async function() {
-                             var testSetup = await setup(accounts);
-                             var beneficiary = accounts[2];
-                             var _signaturesReqToCancel = 5;
-                             var amountPerPeriod =3;
-                             var startingBlock =   web3.eth.blockNumber;
-                             var numberOfAgreedPeriods = 7;
-                             var _signersArray = [];
-                             var periodLength = 1;
-                             var cliffInPeriods = 0;
-                             for (var i=0;i<_signaturesReqToCancel;i++){
-                               _signersArray[i] = accounts[i];
-                             }
-
-                             await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                             var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                            beneficiary,
-                                                                                            accounts[1],
-                                                                                            startingBlock,
-                                                                                            amountPerPeriod,
-                                                                                            periodLength,
-                                                                                            numberOfAgreedPeriods,
-                                                                                            cliffInPeriods,
-                                                                                            _signaturesReqToCancel,
-                                                                                            _signersArray,{from:accounts[1]});
-                             var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                             tx = await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
-                             assert.equal(tx.logs.length, 1);
-                             assert.equal(tx.logs[0].event, "Collect");
-                             var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
-                             var periodsFromStartingBlock = Math.floor((web3.eth.blockNumber-startingBlock)/(periodLength));
-                             assert.equal(balance.toNumber(),periodsFromStartingBlock*amountPerPeriod);
-                            });
-
-                            it("collect log periodsFromStartingBlock >= agreement.numOfAgreedPeriods", async function() {
-                              var testSetup = await setup(accounts);
-                              var beneficiary = accounts[2];
-                              var _signaturesReqToCancel = 5;
-                              var amountPerPeriod =3;
-                              var startingBlock =   web3.eth.blockNumber;
-                              var numberOfAgreedPeriods = 2;
-                              var _signersArray = [];
-                              var periodLength = 1;
-                              var cliffInPeriods = 0;
-                              for (var i=0;i<_signaturesReqToCancel;i++){
-                                _signersArray[i] = accounts[i];
-                              }
-
-                              await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                              var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                             beneficiary,
-                                                                                             accounts[1],
-                                                                                             startingBlock,
-                                                                                             amountPerPeriod,
-                                                                                             periodLength,
-                                                                                             numberOfAgreedPeriods,
-                                                                                             cliffInPeriods,
-                                                                                             _signaturesReqToCancel,
-                                                                                             _signersArray,{from:accounts[1]});
-                              var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                              tx = await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
-                              assert.equal(tx.logs.length, 1);
-                              assert.equal(tx.logs[0].event, "Collect");
-                              var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
-                              //if (periodsFromStartingBlock >= numberOfAgreedPeriods){
-                                  assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
-                             });
+        await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+        var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                       beneficiary,
+                                                                       accounts[1],
+                                                                       startingBlock,
+                                                                       amountPerPeriod,
+                                                                       periodLength,
+                                                                       numberOfAgreedPeriods,
+                                                                       cliffInPeriods,
+                                                                       _signaturesReqToCancel,
+                                                                       _signersArray,{from:accounts[1]});
+        var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+        tx = await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "Collect");
+        var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
+        //if (periodsFromStartingBlock >= numberOfAgreedPeriods){
+            assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
+       });
 
 
-                            it("collect check periodsFromStartingBlock >= agreement.cliffInPeriods", async function() {
-                              var testSetup = await setup(accounts);
-                              var beneficiary = accounts[2];
-                              var _signaturesReqToCancel = 5;
-                              var amountPerPeriod =3;
-                              var startingBlock =   web3.eth.blockNumber;
-                              var numberOfAgreedPeriods = 7;
-                              var _signersArray = [];
-                              var periodLength = 1;
-                              var cliffInPeriods = 100;
-                              for (var i=0;i<_signaturesReqToCancel;i++){
-                                _signersArray[i] = accounts[i];
-                              }
+    it("collect check periodsFromStartingBlock >= agreement.cliffInPeriods", async function() {
+      var testSetup = await setup(accounts);
+      var beneficiary = accounts[2];
+      var _signaturesReqToCancel = 5;
+      var amountPerPeriod =3;
+      var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+      var numberOfAgreedPeriods = 7;
+      var _signersArray = [];
+      var periodLength = 1;
+      var cliffInPeriods = 100;
+      for (var i=0;i<_signaturesReqToCancel;i++){
+        _signersArray[i] = accounts[i];
+      }
 
-                              await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                              var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                             beneficiary,
-                                                                                             accounts[1],
-                                                                                             startingBlock,
-                                                                                             amountPerPeriod,
-                                                                                             periodLength,
-                                                                                             numberOfAgreedPeriods,
-                                                                                             cliffInPeriods,
-                                                                                             _signaturesReqToCancel,
-                                                                                             _signersArray,{from:accounts[1]});
-                              var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                              try{
-                              await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
-                              assert(false,"collect should fail - due to cliff value ");
-                              }catch(ex){
-                                helpers.assertVMException(ex);
-                              }
-                             });
+      await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+      var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                     beneficiary,
+                                                                     accounts[1],
+                                                                     startingBlock,
+                                                                     amountPerPeriod,
+                                                                     periodLength,
+                                                                     numberOfAgreedPeriods,
+                                                                     cliffInPeriods,
+                                                                     _signaturesReqToCancel,
+                                                                     _signersArray,{from:accounts[1]});
+      var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+      try{
+      await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
+      assert(false,"collect should fail - due to cliff value ");
+      }catch(ex){
+        helpers.assertVMException(ex);
+      }
+     });
 
-                             it("collect from none beneficiary", async function() {
-                               var testSetup = await setup(accounts);
-                               var beneficiary = accounts[2];
-                               var _signaturesReqToCancel = 5;
-                               var amountPerPeriod =3;
-                               var startingBlock =   web3.eth.blockNumber;
-                               var numberOfAgreedPeriods = 7;
-                               var _signersArray = [];
-                               var periodLength = 1;
-                               var cliffInPeriods = 100;
-                               for (var i=0;i<_signaturesReqToCancel;i++){
-                                 _signersArray[i] = accounts[i];
-                               }
+     it("collect from none beneficiary", async function() {
+       var testSetup = await setup(accounts);
+       var beneficiary = accounts[2];
+       var _signaturesReqToCancel = 5;
+       var amountPerPeriod =3;
+       var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+       var numberOfAgreedPeriods = 7;
+       var _signersArray = [];
+       var periodLength = 1;
+       var cliffInPeriods = 100;
+       for (var i=0;i<_signaturesReqToCancel;i++){
+         _signersArray[i] = accounts[i];
+       }
 
-                               await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                               var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                              beneficiary,
-                                                                                              accounts[1],
-                                                                                              startingBlock,
-                                                                                              amountPerPeriod,
-                                                                                              periodLength,
-                                                                                              numberOfAgreedPeriods,
-                                                                                              cliffInPeriods,
-                                                                                              _signaturesReqToCancel,
-                                                                                              _signersArray,{from:accounts[1]});
-                               var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                               try{
-                               await testSetup.vestingScheme.collect(agreementId,{from:accounts[1]});
-                               assert(false,"collect should fail - try to collect from none beneficiary ");
-                               }catch(ex){
-                                 helpers.assertVMException(ex);
-                               }
-                              });
+       await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+       var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                      beneficiary,
+                                                                      accounts[1],
+                                                                      startingBlock,
+                                                                      amountPerPeriod,
+                                                                      periodLength,
+                                                                      numberOfAgreedPeriods,
+                                                                      cliffInPeriods,
+                                                                      _signaturesReqToCancel,
+                                                                      _signersArray,{from:accounts[1]});
+       var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+       try{
+       await testSetup.vestingScheme.collect(agreementId,{from:accounts[1]});
+       assert(false,"collect should fail - try to collect from none beneficiary ");
+       }catch(ex){
+         helpers.assertVMException(ex);
+       }
+      });
 
-                              it("collect update collectedPeriods", async function() {
-                                var testSetup = await setup(accounts);
-                                var beneficiary = accounts[2];
-                                var _signaturesReqToCancel = 5;
-                                var amountPerPeriod =3;
-                                var startingBlock =   web3.eth.blockNumber;
-                                var numberOfAgreedPeriods = 7;
-                                var _signersArray = [];
-                                var periodLength = 1;
-                                var cliffInPeriods = 0;
-                                for (var i=0;i<_signaturesReqToCancel;i++){
-                                  _signersArray[i] = accounts[i];
-                                }
+      it("collect update collectedPeriods", async function() {
+        var testSetup = await setup(accounts);
+        var beneficiary = accounts[2];
+        var _signaturesReqToCancel = 5;
+        var amountPerPeriod =3;
+        var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+        var numberOfAgreedPeriods = 7;
+        var _signersArray = [];
+        var periodLength = 1;
+        var cliffInPeriods = 0;
+        for (var i=0;i<_signaturesReqToCancel;i++){
+          _signersArray[i] = accounts[i];
+        }
 
-                                await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                                var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                               beneficiary,
-                                                                                               accounts[1],
-                                                                                               startingBlock,
-                                                                                               amountPerPeriod,
-                                                                                               periodLength,
-                                                                                               numberOfAgreedPeriods,
-                                                                                               cliffInPeriods,
-                                                                                               _signaturesReqToCancel,
-                                                                                               _signersArray,{from:accounts[1]});
-                                var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
-                                await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
-                                var periodsFromStartingBlock = Math.floor((web3.eth.blockNumber-startingBlock)/(periodLength));
-                                var agreement = await testSetup.vestingScheme.agreements(agreementId);
-                                assert.equal(agreement[9],periodsFromStartingBlock);//collectedPeriods
-                               });
+        await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
 
-                               it("collect update collectedPeriods and collect again", async function() {
-                                 var testSetup = await setup(accounts);
-                                 var beneficiary = accounts[2];
-                                 var _signaturesReqToCancel = 5;
-                                 var amountPerPeriod =3;
-                                 var startingBlock =   web3.eth.blockNumber;
-                                 var numberOfAgreedPeriods = 7;
-                                 var _signersArray = [];
-                                 var periodLength = 1;
-                                 var cliffInPeriods = 0;
-                                 for (var i=0;i<_signaturesReqToCancel;i++){
-                                   _signersArray[i] = accounts[i];
-                                 }
+        var tx = await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                       beneficiary,
+                                                                       accounts[1],
+                                                                       startingBlock,
+                                                                       amountPerPeriod,
+                                                                       periodLength,
+                                                                       numberOfAgreedPeriods,
+                                                                       cliffInPeriods,
+                                                                       _signaturesReqToCancel,
+                                                                       _signersArray,{from:accounts[1]});
+        var agreementId = await helpers.getValueFromLogs(tx, '_agreementId',1);
+        await testSetup.vestingScheme.collect(agreementId,{from:beneficiary});
+        var periodsFromStartingBlock = Math.floor((await web3.eth.getBlockNumber()-startingBlock)/(periodLength));
+        var agreement = await testSetup.vestingScheme.agreements(agreementId);
+        assert.equal(agreement[9],periodsFromStartingBlock);//collectedPeriods
+       });
 
-                                 await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
-                                 await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
-                                                                                                beneficiary,
-                                                                                                accounts[1],
-                                                                                                startingBlock,
-                                                                                                amountPerPeriod,
-                                                                                                periodLength,
-                                                                                                numberOfAgreedPeriods,
-                                                                                                cliffInPeriods,
-                                                                                                _signaturesReqToCancel,
-                                                                                                _signersArray,{from:accounts[1]});
-                                 for (i=0;i<numberOfAgreedPeriods;i++){
-                                  await testSetup.vestingScheme.collect(0,{from:beneficiary});
-                                  var periodsFromStartingBlock = Math.floor((web3.eth.blockNumber-startingBlock)/(periodLength));
-                                  var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
-                                  if (periodsFromStartingBlock < numberOfAgreedPeriods){
-                                   assert.equal(balance.toNumber(),periodsFromStartingBlock*amountPerPeriod);
-                                 }else {
-                                   assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
-                                 }
-                               }
-                                });
+       it("collect update collectedPeriods and collect again", async function() {
+         var testSetup = await setup(accounts);
+         var beneficiary = accounts[2];
+         var _signaturesReqToCancel = 5;
+         var amountPerPeriod =3;
+         var startingBlock =   await (web3.utils.toBN(await web3.eth.getBlockNumber()));
+         var numberOfAgreedPeriods = 7;
+         var _signersArray = [];
+         var periodLength = 1;
+         var cliffInPeriods = 0;
+         for (var i=0;i<_signaturesReqToCancel;i++){
+           _signersArray[i] = accounts[i];
+         }
 
-
-
+         await testSetup.standardTokenMock.approve(testSetup.vestingScheme.address,100,{from:accounts[1]});
+         await testSetup.vestingScheme.createVestedAgreement(  testSetup.standardTokenMock.address,
+                                                                        beneficiary,
+                                                                        accounts[1],
+                                                                        startingBlock,
+                                                                        amountPerPeriod,
+                                                                        periodLength,
+                                                                        numberOfAgreedPeriods,
+                                                                        cliffInPeriods,
+                                                                        _signaturesReqToCancel,
+                                                                        _signersArray,{from:accounts[1]});
+         for (i=0;i<numberOfAgreedPeriods;i++){
+          await testSetup.vestingScheme.collect(0,{from:beneficiary});
+          var periodsFromStartingBlock = Math.floor((await web3.eth.getBlockNumber()-startingBlock)/(periodLength));
+          var balance = await testSetup.standardTokenMock.balanceOf(beneficiary);
+          if (periodsFromStartingBlock < numberOfAgreedPeriods){
+           assert.equal(balance.toNumber(),periodsFromStartingBlock*amountPerPeriod);
+         }else {
+           assert.equal(balance.toNumber(),numberOfAgreedPeriods*amountPerPeriod);
+         }
+       }
+        });
 
 
 });

--- a/test/voteinorganization.js
+++ b/test/voteinorganization.js
@@ -74,11 +74,11 @@ const setup = async function (accounts,reputationAccount=0,genesisProtocol = fal
    return testSetup;
 };
 
-contract('VoteInOrganizationScheme', function(accounts) {
+contract('VoteInOrganizationScheme', accounts => {
   before(function() {
-    helpers.etherForEveryone();
+     helpers.etherForEveryone(accounts);
   });
-   it("setParameters", async function() {
+   it("setParameters", async() => {
      var voteInOrganization = await VoteInOrganizationScheme.new();
      var absoluteVote = await AbsoluteVote.new();
      await voteInOrganization.setParameters("0x1234",absoluteVote.address);

--- a/truffle.js
+++ b/truffle.js
@@ -34,7 +34,7 @@ module.exports = {
       network_id: "*",
       host: "localhost",
       port: 8545,
-      gas: 5900000
+      gas: 4543760
     },
   },
   rpc: {

--- a/truffle.js
+++ b/truffle.js
@@ -34,8 +34,12 @@ module.exports = {
       network_id: "*",
       host: "localhost",
       port: 8545,
-      gas: 4543760
+      gas: 5900000
     },
+  },
+  rpc: {
+    host: "localhost",
+    port: 8545
   },
   solc: {
     optimizer: {
@@ -43,8 +47,14 @@ module.exports = {
       runs: 200
     }
   },
-  rpc: {
-    host: "localhost",
-    port: 8545
+  compilers: {
+    solc: {
+         version: "0.4.24",    // Fetch exact version from solc-bin (default: truffle's version)
+      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+      optimizer: {
+        enabled: true,
+        runs: 200
+      }
+      }
   }
 };


### PR DESCRIPTION
- Use [truffle v5](https://github.com/trufflesuite/truffle/releases/tag/v5.0.0-beta.0) .
- Update tests to use web3 1.0 .
- ganache-cli 6.1.8
- fix bug in migration script

- ContributionReward.sol  getPeriodsToPay - validate redeemType range.

- resolve #536 
 
