### PR TITLE
locking schems : add setParameters (one time call)

### DIFF
--- a/contracts/schemes/Auction4Reputation.sol
+++ b/contracts/schemes/Auction4Reputation.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.4.24;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { RealMath } from "../libs/RealMath.sol";
 import "../controller/ControllerInterface.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 /**
  * @title A scheme for conduct ERC20 Tokens auction for reputation
  */
 
 
-contract Auction4Reputation {
+contract Auction4Reputation is Ownable {
     using SafeMath for uint;
     using RealMath for int216;
     using RealMath for int256;
@@ -38,7 +39,7 @@ contract Auction4Reputation {
     address public wallet;
 
     /**
-     * @dev constructor
+     * @dev setParameters
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for the token locking
@@ -49,15 +50,19 @@ contract Auction4Reputation {
      * @param _numberOfAuctions number of auctions.
      * @param _token the bidding token
      */
-    constructor(Avatar _avatar,
-                 uint _reputationReward,
-                 uint _auctionsStartTime,
-                 uint _auctionsEndTime,
-                 uint _numberOfAuctions,
-                 StandardToken _token,
-                 address _wallet)
-    public
-    {
+    function setParameters(
+        Avatar _avatar,
+        uint _reputationReward,
+        uint _auctionsStartTime,
+        uint _auctionsEndTime,
+        uint _numberOfAuctions,
+        StandardToken _token,
+        address _wallet)
+       external
+       onlyOwner
+       {
+        require(avatar == Avatar(0),"can be called only one time");
+        require(_avatar != Avatar(0),"avatar cannot be zero");
         //number of auctions cannot be zero
         //auctionsEndTime should be greater than auctionsStartTime
         auctionPeriod = (_auctionsEndTime.sub(_auctionsStartTime)).div(_numberOfAuctions);

--- a/contracts/schemes/Auction4Reputation.sol
+++ b/contracts/schemes/Auction4Reputation.sol
@@ -39,7 +39,7 @@ contract Auction4Reputation is Ownable {
     address public wallet;
 
     /**
-     * @dev setParameters
+     * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for the token locking
@@ -50,7 +50,7 @@ contract Auction4Reputation is Ownable {
      * @param _numberOfAuctions number of auctions.
      * @param _token the bidding token
      */
-    function setParameters(
+    function initialize(
         Avatar _avatar,
         uint _reputationReward,
         uint _auctionsStartTime,

--- a/contracts/schemes/ExternalLocking4Reputation.sol
+++ b/contracts/schemes/ExternalLocking4Reputation.sol
@@ -17,7 +17,7 @@ contract ExternalLocking4Reputation is Locking4Reputation,Ownable {
     mapping(address=>bool) public externalLockers;
 
     /**
-     * @dev constructor
+     * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for the token locking
@@ -29,7 +29,7 @@ contract ExternalLocking4Reputation is Locking4Reputation,Ownable {
      * @param _getBalanceFuncSignature get balance function signature
      *        e.g "lockedTokenBalances(address)"
      */
-    function setParameters(
+    function initialize(
         Avatar _avatar,
         uint _reputationReward,
         uint _lockingStartTime,
@@ -42,7 +42,7 @@ contract ExternalLocking4Reputation is Locking4Reputation,Ownable {
         require(_lockingEndTime > _lockingStartTime,"_lockingEndTime should be greater than _lockingStartTime");
         externalLockingContract = _externalLockingContract;
         getBalanceFuncSignature = _getBalanceFuncSignature;
-        super._setParameters(
+        super._initialize(
         _avatar,
         _reputationReward,
         _lockingStartTime,
@@ -55,7 +55,7 @@ contract ExternalLocking4Reputation is Locking4Reputation,Ownable {
      * @return lockingId
      */
     function lock() public returns(bytes32) {
-        require(avatar != Avatar(0),"should setParameters first");
+        require(avatar != Avatar(0),"should initialize first");
         require(externalLockers[msg.sender] == false,"locking twice is not allowed");
         externalLockers[msg.sender] = true;
         // solium-disable-next-line security/no-low-level-calls

--- a/contracts/schemes/ExternalLocking4Reputation.sol
+++ b/contracts/schemes/ExternalLocking4Reputation.sol
@@ -1,13 +1,14 @@
 pragma solidity ^0.4.24;
 
 import "./Locking4Reputation.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 
 /**
  * @title A scheme for external locking Tokens for reputation
  */
 
-contract ExternalLocking4Reputation is Locking4Reputation {
+contract ExternalLocking4Reputation is Locking4Reputation,Ownable {
 
     address public externalLockingContract;
     string public getBalanceFuncSignature;
@@ -28,22 +29,25 @@ contract ExternalLocking4Reputation is Locking4Reputation {
      * @param _getBalanceFuncSignature get balance function signature
      *        e.g "lockedTokenBalances(address)"
      */
-    constructor(Avatar _avatar,
-                 uint _reputationReward,
-                 uint _lockingStartTime,
-                 uint _lockingEndTime,
-                 address _externalLockingContract,
-                 string _getBalanceFuncSignature)
-    Locking4Reputation(_avatar,
-                       _reputationReward,
-                       _lockingStartTime,
-                       _lockingEndTime,
-                       1)
-    public
+    function setParameters(
+        Avatar _avatar,
+        uint _reputationReward,
+        uint _lockingStartTime,
+        uint _lockingEndTime,
+        address _externalLockingContract,
+        string _getBalanceFuncSignature)
+    external
+    onlyOwner
     {
         require(_lockingEndTime > _lockingStartTime,"_lockingEndTime should be greater than _lockingStartTime");
         externalLockingContract = _externalLockingContract;
         getBalanceFuncSignature = _getBalanceFuncSignature;
+        super._setParameters(
+        _avatar,
+        _reputationReward,
+        _lockingStartTime,
+        _lockingEndTime,
+        1);
     }
 
     /**
@@ -51,6 +55,7 @@ contract ExternalLocking4Reputation is Locking4Reputation {
      * @return lockingId
      */
     function lock() public returns(bytes32) {
+        require(avatar != Avatar(0),"should setParameters first");
         require(externalLockers[msg.sender] == false,"locking twice is not allowed");
         externalLockers[msg.sender] = true;
         // solium-disable-next-line security/no-low-level-calls

--- a/contracts/schemes/FixReputationAllocation.sol
+++ b/contracts/schemes/FixReputationAllocation.sol
@@ -29,11 +29,11 @@ contract FixedReputationAllocation is Ownable {
     uint public beneficiaryReward;
 
     /**
-     * @dev setParameters
+     * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      */
-    function setParameters(
+    function initialize(
         Avatar _avatar,
         uint _reputationReward)
     external

--- a/contracts/schemes/FixReputationAllocation.sol
+++ b/contracts/schemes/FixReputationAllocation.sol
@@ -29,14 +29,17 @@ contract FixedReputationAllocation is Ownable {
     uint public beneficiaryReward;
 
     /**
-     * @dev constructor
+     * @dev setParameters
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      */
-    constructor(Avatar _avatar,
-                uint _reputationReward)
-    public
+    function setParameters(
+        Avatar _avatar,
+        uint _reputationReward)
+    external
+    onlyOwner
     {
+        require(avatar == Avatar(0),"can be called only one time");
         reputationReward = _reputationReward;
         avatar = _avatar;
     }

--- a/contracts/schemes/Locking4Reputation.sol
+++ b/contracts/schemes/Locking4Reputation.sol
@@ -40,33 +40,6 @@ contract Locking4Reputation {
     uint public lockingStartTime;
 
     /**
-     * @dev constructor
-     * @param _avatar the avatar to mint reputation from
-     * @param _reputationReward the total reputation this contract will reward
-     *        for eth/token locking
-     * @param _lockingStartTime the locking start time.
-     * @param _lockingEndTime the locking end time.
-     *        redeem reputation can be done after this period.
-     *        locking is disable after this time.
-     * @param _maxLockingPeriod maximum locking period allowed.
-     */
-    constructor(Avatar _avatar,
-                uint _reputationReward,
-                uint _lockingStartTime,
-                uint _lockingEndTime,
-                uint _maxLockingPeriod)
-    public
-    {
-        require(_lockingEndTime > _lockingStartTime,"locking end time should be greater than locking start time");
-        reputationReward = _reputationReward;
-        reputationRewardLeft = reputationReward;
-        lockingEndTime = _lockingEndTime;
-        maxLockingPeriod = _maxLockingPeriod;
-        avatar = _avatar;
-        lockingStartTime = _lockingStartTime;
-    }
-
-    /**
      * @dev redeem reputation function
      * @param _beneficiary the beneficiary for the release
      * @param _lockingId the locking id to release
@@ -133,6 +106,36 @@ contract Locking4Reputation {
         scores[_locker] = scores[_locker].add(_period.mul(_amount));
         totalScore = totalScore.add(scores[_locker]);
         emit Lock(lockingId,_amount,_period,_locker);
+    }
+
+    /**
+     * @dev setParameters
+     * @param _avatar the avatar to mint reputation from
+     * @param _reputationReward the total reputation this contract will reward
+     *        for eth/token locking
+     * @param _lockingStartTime the locking start time.
+     * @param _lockingEndTime the locking end time.
+     *        redeem reputation can be done after this period.
+     *        locking is disable after this time.
+     * @param _maxLockingPeriod maximum locking period allowed.
+     */
+    function _setParameters(
+        Avatar _avatar,
+        uint _reputationReward,
+        uint _lockingStartTime,
+        uint _lockingEndTime,
+        uint _maxLockingPeriod)
+    internal
+    {
+        require(avatar == Avatar(0),"can be called only one time");
+        require(_avatar != Avatar(0),"avatar cannot be zero");
+        require(_lockingEndTime > _lockingStartTime,"locking end time should be greater than locking start time");
+        reputationReward = _reputationReward;
+        reputationRewardLeft = reputationReward;
+        lockingEndTime = _lockingEndTime;
+        maxLockingPeriod = _maxLockingPeriod;
+        avatar = _avatar;
+        lockingStartTime = _lockingStartTime;
     }
 
 }

--- a/contracts/schemes/Locking4Reputation.sol
+++ b/contracts/schemes/Locking4Reputation.sol
@@ -109,7 +109,7 @@ contract Locking4Reputation {
     }
 
     /**
-     * @dev setParameters
+     * @dev _initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for eth/token locking
@@ -119,7 +119,7 @@ contract Locking4Reputation {
      *        locking is disable after this time.
      * @param _maxLockingPeriod maximum locking period allowed.
      */
-    function _setParameters(
+    function _initialize(
         Avatar _avatar,
         uint _reputationReward,
         uint _lockingStartTime,

--- a/contracts/schemes/LockingEth4Reputation.sol
+++ b/contracts/schemes/LockingEth4Reputation.sol
@@ -11,7 +11,7 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 contract LockingEth4Reputation is Locking4Reputation,Ownable {
 
     /**
-     * @dev setParameters
+     * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for eth locking
@@ -21,7 +21,7 @@ contract LockingEth4Reputation is Locking4Reputation,Ownable {
      *        locking is disable after this time.
      * @param _maxLockingPeriod maximum locking period allowed.
      */
-    function setParameters(
+    function initialize(
         Avatar _avatar,
         uint _reputationReward,
         uint _lockingStartTime,
@@ -30,7 +30,7 @@ contract LockingEth4Reputation is Locking4Reputation,Ownable {
     external
     onlyOwner
     {
-        super._setParameters(
+        super._initialize(
         _avatar,
         _reputationReward,
         _lockingStartTime,

--- a/contracts/schemes/LockingEth4Reputation.sol
+++ b/contracts/schemes/LockingEth4Reputation.sol
@@ -1,16 +1,17 @@
 pragma solidity ^0.4.24;
 
 import "./Locking4Reputation.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 
 /**
  * @title A scheme for locking ETH for reputation
  */
 
-contract LockingEth4Reputation is Locking4Reputation {
+contract LockingEth4Reputation is Locking4Reputation,Ownable {
 
     /**
-     * @dev constructor
+     * @dev setParameters
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for eth locking
@@ -20,18 +21,22 @@ contract LockingEth4Reputation is Locking4Reputation {
      *        locking is disable after this time.
      * @param _maxLockingPeriod maximum locking period allowed.
      */
-    constructor(Avatar _avatar,
-                uint _reputationReward,
-                uint _lockingStartTime,
-                uint _lockingEndTime,
-                uint _maxLockingPeriod)
-    Locking4Reputation(_avatar,
-                      _reputationReward,
-                      _lockingStartTime,
-                      _lockingEndTime,
-                      _maxLockingPeriod)
-    public
-    {}
+    function setParameters(
+        Avatar _avatar,
+        uint _reputationReward,
+        uint _lockingStartTime,
+        uint _lockingEndTime,
+        uint _maxLockingPeriod)
+    external
+    onlyOwner
+    {
+        super._setParameters(
+        _avatar,
+        _reputationReward,
+        _lockingStartTime,
+        _lockingEndTime,
+        _maxLockingPeriod);
+    }
 
     /**
      * @dev release locked eth

--- a/contracts/schemes/LockingToken4Reputation.sol
+++ b/contracts/schemes/LockingToken4Reputation.sol
@@ -1,13 +1,14 @@
 pragma solidity ^0.4.24;
 
 import "./Locking4Reputation.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 
 /**
  * @title A scheme for locking ERC20 Tokens for reputation
  */
 
-contract LockingToken4Reputation is Locking4Reputation {
+contract LockingToken4Reputation is Locking4Reputation,Ownable {
 
     StandardToken public token;
 
@@ -23,20 +24,23 @@ contract LockingToken4Reputation is Locking4Reputation {
      * @param _maxLockingPeriod maximum locking period allowed.
      * @param _token the locking token
      */
-    constructor(Avatar _avatar,
-                 uint _reputationReward,
-                 uint _lockingStartTime,
-                 uint _lockingEndTime,
-                 uint _maxLockingPeriod,
-                 StandardToken _token)
-    Locking4Reputation(_avatar,
-                       _reputationReward,
-                       _lockingStartTime,
-                       _lockingEndTime,
-                       _maxLockingPeriod)
-    public
+    function setParameters(
+        Avatar _avatar,
+        uint _reputationReward,
+        uint _lockingStartTime,
+        uint _lockingEndTime,
+        uint _maxLockingPeriod,
+        StandardToken _token)
+    external
+    onlyOwner
     {
         token = _token;
+        super._setParameters(
+        _avatar,
+        _reputationReward,
+        _lockingStartTime,
+        _lockingEndTime,
+        _maxLockingPeriod);
     }
 
     /**

--- a/contracts/schemes/LockingToken4Reputation.sol
+++ b/contracts/schemes/LockingToken4Reputation.sol
@@ -13,7 +13,7 @@ contract LockingToken4Reputation is Locking4Reputation,Ownable {
     StandardToken public token;
 
     /**
-     * @dev constructor
+     * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for the token locking
@@ -24,7 +24,7 @@ contract LockingToken4Reputation is Locking4Reputation,Ownable {
      * @param _maxLockingPeriod maximum locking period allowed.
      * @param _token the locking token
      */
-    function setParameters(
+    function initialize(
         Avatar _avatar,
         uint _reputationReward,
         uint _lockingStartTime,
@@ -35,7 +35,7 @@ contract LockingToken4Reputation is Locking4Reputation,Ownable {
     onlyOwner
     {
         token = _token;
-        super._setParameters(
+        super._initialize(
         _avatar,
         _reputationReward,
         _lockingStartTime,

--- a/test/auction4reputation.js
+++ b/test/auction4reputation.js
@@ -17,8 +17,8 @@ const setup = async function (accounts,
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.auctionsEndTime = await web3.eth.getBlock("latest").timestamp + _auctionsEndTime;
-   testSetup.auctionsStartTime = await web3.eth.getBlock("latest").timestamp + _auctionsStartTime;
+   testSetup.auctionsEndTime = (await web3.eth.getBlock("latest")).timestamp + _auctionsEndTime;
+   testSetup.auctionsStartTime = (await web3.eth.getBlock("latest")).timestamp + _auctionsStartTime;
    testSetup.auction4Reputation = await Auction4Reputation.new();
    if (_initialize === true ) {
      await testSetup.auction4Reputation.initialize(testSetup.org.avatar.address,
@@ -140,7 +140,7 @@ contract('Auction4Reputation', accounts => {
     it("bid without initialize should fail", async () => {
       let testSetup = await setup(accounts,300,0,3000,3,false);
       try {
-        await testSetup.auction4Reputation.bid(web3.toWei('1', "ether"));
+        await testSetup.auction4Reputation.bid(web3.utils.toWei('1', "ether"));
         assert(false, "bid without initialize should fail");
       } catch(error) {
         helpers.assertVMException(error);

--- a/test/auction4reputation.js
+++ b/test/auction4reputation.js
@@ -5,22 +5,31 @@ const constants = require('./constants');
 const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 var Auction4Reputation = artifacts.require("./Auction4Reputation.sol");
 
-const setup = async function (accounts,_repAllocation = 300,_auctionsStartTime = 0,_auctionsEndTime = 3000,_numberOfAuctions = 3) {
+
+const setup = async function (accounts,
+                             _repAllocation = 300,
+                             _auctionsStartTime = 0,
+                             _auctionsEndTime = 3000,
+                             _numberOfAuctions = 3,
+                             _setParameters = true) {
    var testSetup = new helpers.TestSetup();
    testSetup.biddingToken = await StandardTokenMock.new(accounts[0], web3.utils.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   var latestBlock = await web3.eth.getBlock("latest");
-   testSetup.auctionsEndTime =   latestBlock.timestamp + _auctionsEndTime;
-   testSetup.auctionsStartTime = latestBlock.timestamp + _auctionsStartTime;
-   testSetup.auction4Reputation = await Auction4Reputation.new(testSetup.org.avatar.address,
-                                                                       _repAllocation,
-                                                                      testSetup.auctionsStartTime,
-                                                                      testSetup.auctionsEndTime,
-                                                                      _numberOfAuctions,
-                                                                      testSetup.biddingToken.address,
-                                                                      testSetup.org.avatar.address);
+   testSetup.auctionsEndTime = await web3.eth.getBlock("latest").timestamp + _auctionsEndTime;
+   testSetup.auctionsStartTime = await web3.eth.getBlock("latest").timestamp + _auctionsStartTime;
+   testSetup.auction4Reputation = await Auction4Reputation.new();
+   if (_setParameters === true ) {
+     await testSetup.auction4Reputation.setParameters(testSetup.org.avatar.address,
+                                                     _repAllocation,
+                                                     testSetup.auctionsStartTime,
+                                                     testSetup.auctionsEndTime,
+                                                     _numberOfAuctions,
+                                                     testSetup.biddingToken.address,
+                                                     testSetup.org.avatar.address,
+                                                     {gas : constants.ARC_GAS_LIMIT});
+   }
 
    var permissions = "0x00000000";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.auction4Reputation.address],[web3.utils.asciiToHex("0")],[permissions]);
@@ -29,7 +38,7 @@ const setup = async function (accounts,_repAllocation = 300,_auctionsStartTime =
 };
 
 contract('Auction4Reputation', accounts => {
-    it("constructor", async () => {
+    it("setParameters", async () => {
       let testSetup = await setup(accounts);
 
       assert.equal(await testSetup.auction4Reputation.reputationReward(),300);
@@ -41,45 +50,74 @@ contract('Auction4Reputation', accounts => {
       assert.equal(await testSetup.auction4Reputation.auctionPeriod(),(testSetup.auctionsEndTime-testSetup.auctionsStartTime)/3);
     });
 
-    it("constructor numberOfAuctions = 0  is not allowed", async () => {
+    it("setParameters numberOfAuctions = 0  is not allowed", async () => {
+      var auction4Reputation = await Auction4Reputation.new();
       try {
-        await Auction4Reputation.new(accounts[0],
-                                     300,
-                                     0,
-                                     3000,
-                                     0,
-                                    accounts[0],
-                                    accounts[0]);
+        await auction4Reputation.setParameters(accounts[0],
+                                               300,
+                                               0,
+                                               3000,
+                                               0,
+                                              accounts[0],
+                                              accounts[0],
+                                              {gas :constants.ARC_GAS_LIMIT});
         assert(false, "numberOfAuctions = 0  is not allowed");
       } catch(error) {
         helpers.assertVMException(error);
       }
     });
 
-    it("constructor auctionsEndTime = auctionsStartTime is not allowed", async () => {
+    it("setParameters is onlyOwner", async () => {
+      var auction4Reputation = await Auction4Reputation.new();
       try {
-        await Auction4Reputation.new(accounts[0],
-                                     300,
-                                     300,
-                                     300,
-                                     1,
-                                    accounts[0],
-                                    accounts[0]);
+        await auction4Reputation.setParameters(accounts[0],
+                                               300,
+                                               0,
+                                               3000,
+                                               1,
+                                              accounts[0],
+                                              accounts[0],
+                                              {gas :constants.ARC_GAS_LIMIT,from:accounts[1]});
+        assert(false, "setParameters is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+      await auction4Reputation.setParameters(accounts[0],
+                                             300,
+                                             0,
+                                             3000,
+                                             1,
+                                            accounts[0],
+                                            accounts[0],
+                                          {gas :constants.ARC_GAS_LIMIT,from:accounts[0]});
+    });
+
+    it("setParameters auctionsEndTime = auctionsStartTime is not allowed", async () => {
+      var auction4Reputation = await Auction4Reputation.new();
+      try {
+        await auction4Reputation.setParameters(accounts[0],
+                                               300,
+                                               300,
+                                               300,
+                                               1,
+                                              accounts[0],
+                                              accounts[0]);
         assert(false, "auctionsEndTime = auctionsStartTime is not allowed");
       } catch(error) {
         helpers.assertVMException(error);
       }
     });
 
-    it("constructor auctionsEndTime < auctionsStartTime is not allowed", async () => {
+    it("setParameters auctionsEndTime < auctionsStartTime is not allowed", async () => {
+      var auction4Reputation = await Auction4Reputation.new();
       try {
-        await Auction4Reputation.new(accounts[0],
-                                     300,
-                                     200,
-                                     100,
-                                     1,
-                                    accounts[0],
-                                    accounts[0]);
+        await auction4Reputation.setParameters(accounts[0],
+                                               300,
+                                               200,
+                                               100,
+                                               1,
+                                              accounts[0],
+                                              accounts[0]);
         assert(false, "auctionsEndTime < auctionsStartTime is not allowed");
       } catch(error) {
         helpers.assertVMException(error);
@@ -97,6 +135,16 @@ contract('Auction4Reputation', accounts => {
       assert.equal(tx.logs[0].args._bidder,accounts[0]);
       //test the tokens moved to the wallet.
       assert.equal(await testSetup.biddingToken.balanceOf(testSetup.org.avatar.address),web3.utils.toWei('1', "ether"));
+    });
+
+    it("bid without setParameters should fail", async () => {
+      let testSetup = await setup(accounts,300,0,3000,3,false);
+      try {
+        await testSetup.auction4Reputation.bid(web3.toWei('1', "ether"));
+        assert(false, "bid without setParameters should fail");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
     });
 
     it("bid with value == 0 should revert", async () => {
@@ -212,5 +260,21 @@ contract('Auction4Reputation', accounts => {
         assert.equal(id1.toNumber(),id2.toNumber());
         var bid = await testSetup.auction4Reputation.getBid(accounts[0],id1);
         assert.equal(bid,web3.utils.toWei('2', "ether"));
+    });
+
+    it("cannot setParameters twice", async () => {
+        let testSetup = await setup(accounts);
+        try {
+             await testSetup.auction4Reputation.setParameters(accounts[0],
+                                                              300,
+                                                              200,
+                                                              100,
+                                                              1,
+                                                              accounts[0],
+                                                              accounts[0]);
+             assert(false, "cannot setParameters twice");
+           } catch(error) {
+             helpers.assertVMException(error);
+           }
     });
 });

--- a/test/auction4reputation.js
+++ b/test/auction4reputation.js
@@ -11,7 +11,7 @@ const setup = async function (accounts,
                              _auctionsStartTime = 0,
                              _auctionsEndTime = 3000,
                              _numberOfAuctions = 3,
-                             _setParameters = true) {
+                             _initialize = true) {
    var testSetup = new helpers.TestSetup();
    testSetup.biddingToken = await StandardTokenMock.new(accounts[0], web3.utils.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
@@ -20,8 +20,8 @@ const setup = async function (accounts,
    testSetup.auctionsEndTime = await web3.eth.getBlock("latest").timestamp + _auctionsEndTime;
    testSetup.auctionsStartTime = await web3.eth.getBlock("latest").timestamp + _auctionsStartTime;
    testSetup.auction4Reputation = await Auction4Reputation.new();
-   if (_setParameters === true ) {
-     await testSetup.auction4Reputation.setParameters(testSetup.org.avatar.address,
+   if (_initialize === true ) {
+     await testSetup.auction4Reputation.initialize(testSetup.org.avatar.address,
                                                      _repAllocation,
                                                      testSetup.auctionsStartTime,
                                                      testSetup.auctionsEndTime,
@@ -38,7 +38,7 @@ const setup = async function (accounts,
 };
 
 contract('Auction4Reputation', accounts => {
-    it("setParameters", async () => {
+    it("initialize", async () => {
       let testSetup = await setup(accounts);
 
       assert.equal(await testSetup.auction4Reputation.reputationReward(),300);
@@ -50,10 +50,10 @@ contract('Auction4Reputation', accounts => {
       assert.equal(await testSetup.auction4Reputation.auctionPeriod(),(testSetup.auctionsEndTime-testSetup.auctionsStartTime)/3);
     });
 
-    it("setParameters numberOfAuctions = 0  is not allowed", async () => {
+    it("initialize numberOfAuctions = 0  is not allowed", async () => {
       var auction4Reputation = await Auction4Reputation.new();
       try {
-        await auction4Reputation.setParameters(accounts[0],
+        await auction4Reputation.initialize(accounts[0],
                                                300,
                                                0,
                                                3000,
@@ -67,10 +67,10 @@ contract('Auction4Reputation', accounts => {
       }
     });
 
-    it("setParameters is onlyOwner", async () => {
+    it("initialize is onlyOwner", async () => {
       var auction4Reputation = await Auction4Reputation.new();
       try {
-        await auction4Reputation.setParameters(accounts[0],
+        await auction4Reputation.initialize(accounts[0],
                                                300,
                                                0,
                                                3000,
@@ -78,11 +78,11 @@ contract('Auction4Reputation', accounts => {
                                               accounts[0],
                                               accounts[0],
                                               {gas :constants.ARC_GAS_LIMIT,from:accounts[1]});
-        assert(false, "setParameters is onlyOwner");
+        assert(false, "initialize is onlyOwner");
       } catch(error) {
         helpers.assertVMException(error);
       }
-      await auction4Reputation.setParameters(accounts[0],
+      await auction4Reputation.initialize(accounts[0],
                                              300,
                                              0,
                                              3000,
@@ -92,10 +92,10 @@ contract('Auction4Reputation', accounts => {
                                           {gas :constants.ARC_GAS_LIMIT,from:accounts[0]});
     });
 
-    it("setParameters auctionsEndTime = auctionsStartTime is not allowed", async () => {
+    it("initialize auctionsEndTime = auctionsStartTime is not allowed", async () => {
       var auction4Reputation = await Auction4Reputation.new();
       try {
-        await auction4Reputation.setParameters(accounts[0],
+        await auction4Reputation.initialize(accounts[0],
                                                300,
                                                300,
                                                300,
@@ -108,10 +108,10 @@ contract('Auction4Reputation', accounts => {
       }
     });
 
-    it("setParameters auctionsEndTime < auctionsStartTime is not allowed", async () => {
+    it("initialize auctionsEndTime < auctionsStartTime is not allowed", async () => {
       var auction4Reputation = await Auction4Reputation.new();
       try {
-        await auction4Reputation.setParameters(accounts[0],
+        await auction4Reputation.initialize(accounts[0],
                                                300,
                                                200,
                                                100,
@@ -137,11 +137,11 @@ contract('Auction4Reputation', accounts => {
       assert.equal(await testSetup.biddingToken.balanceOf(testSetup.org.avatar.address),web3.utils.toWei('1', "ether"));
     });
 
-    it("bid without setParameters should fail", async () => {
+    it("bid without initialize should fail", async () => {
       let testSetup = await setup(accounts,300,0,3000,3,false);
       try {
         await testSetup.auction4Reputation.bid(web3.toWei('1', "ether"));
-        assert(false, "bid without setParameters should fail");
+        assert(false, "bid without initialize should fail");
       } catch(error) {
         helpers.assertVMException(error);
       }
@@ -262,17 +262,17 @@ contract('Auction4Reputation', accounts => {
         assert.equal(bid,web3.utils.toWei('2', "ether"));
     });
 
-    it("cannot setParameters twice", async () => {
+    it("cannot initialize twice", async () => {
         let testSetup = await setup(accounts);
         try {
-             await testSetup.auction4Reputation.setParameters(accounts[0],
+             await testSetup.auction4Reputation.initialize(accounts[0],
                                                               300,
                                                               200,
                                                               100,
                                                               1,
                                                               accounts[0],
                                                               accounts[0]);
-             assert(false, "cannot setParameters twice");
+             assert(false, "cannot initialize twice");
            } catch(error) {
              helpers.assertVMException(error);
            }

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -5,7 +5,7 @@ const constants = require('./constants');
 var ExternalLocking4Reputation = artifacts.require("./ExternalLocking4Reputation.sol");
 var ExternalTokenLockerMock = artifacts.require("./ExternalTokenLockerMock.sol");
 
-const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_setParameters = true) {
+const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_initialize = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
@@ -19,8 +19,8 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
    await testSetup.extetnalTokenLockerMock.lock(300,{from:accounts[2]});
 
    testSetup.externalLocking4Reputation = await ExternalLocking4Reputation.new();
-   if (_setParameters === true) {
-     await testSetup.externalLocking4Reputation.setParameters(testSetup.org.avatar.address,
+   if (_initialize === true) {
+     await testSetup.externalLocking4Reputation.initialize(testSetup.org.avatar.address,
                                                              _repAllocation,
                                                              testSetup.lockingStartTime,
                                                              testSetup.lockingEndTime,
@@ -34,7 +34,7 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
 };
 
 contract('ExternalLocking4Reputation', accounts => {
-    it("setParameters", async () => {
+    it("initialize", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.externalLocking4Reputation.reputationReward(),100);
       assert.equal(await testSetup.externalLocking4Reputation.lockingEndTime(),testSetup.lockingEndTime);
@@ -161,36 +161,36 @@ contract('ExternalLocking4Reputation', accounts => {
            }
     });
 
-    it("cannot setParameters twice", async () => {
+    it("cannot initialize twice", async () => {
         let testSetup = await setup(accounts);
         try {
-             await testSetup.externalLocking4Reputation.setParameters(testSetup.org.avatar.address,
+             await testSetup.externalLocking4Reputation.initialize(testSetup.org.avatar.address,
                                                                      100,
                                                                      testSetup.lockingStartTime,
                                                                      testSetup.lockingEndTime,
                                                                      testSetup.extetnalTokenLockerMock.address,
                                                                      "lockedTokenBalances(address)");
-             assert(false, "cannot setParameters twice");
+             assert(false, "cannot initialize twice");
            } catch(error) {
              helpers.assertVMException(error);
            }
     });
 
-    it("setParameters is onlyOwner", async () => {
+    it("initialize is onlyOwner", async () => {
       var externalLocking4Reputation = await ExternalLocking4Reputation.new();
       try {
-        await externalLocking4Reputation.setParameters(accounts[0],
+        await externalLocking4Reputation.initialize(accounts[0],
                                                        100,
                                                        0,
                                                        3000,
                                                        accounts[0],
                                                        "lockedTokenBalances(address)",
                                               {from:accounts[1]});
-        assert(false, "setParameters is onlyOwner");
+        assert(false, "initialize is onlyOwner");
       } catch(error) {
         helpers.assertVMException(error);
       }
-      await externalLocking4Reputation.setParameters(accounts[0],
+      await externalLocking4Reputation.initialize(accounts[0],
                                                      100,
                                                      0,
                                                      3000,

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -5,8 +5,7 @@ const constants = require('./constants');
 var ExternalLocking4Reputation = artifacts.require("./ExternalLocking4Reputation.sol");
 var ExternalTokenLockerMock = artifacts.require("./ExternalTokenLockerMock.sol");
 
-
-const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000) {
+const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_setParameters = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
@@ -19,12 +18,15 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
    await testSetup.extetnalTokenLockerMock.lock(200,{from:accounts[1]});
    await testSetup.extetnalTokenLockerMock.lock(300,{from:accounts[2]});
 
-   testSetup.externalLocking4Reputation = await ExternalLocking4Reputation.new(testSetup.org.avatar.address,
-                                                                       _repAllocation,
-                                                                      testSetup.lockingStartTime,
-                                                                      testSetup.lockingEndTime,
-                                                                      testSetup.extetnalTokenLockerMock.address,
-                                                                      "lockedTokenBalances(address)");
+   testSetup.externalLocking4Reputation = await ExternalLocking4Reputation.new();
+   if (_setParameters === true) {
+     await testSetup.externalLocking4Reputation.setParameters(testSetup.org.avatar.address,
+                                                             _repAllocation,
+                                                             testSetup.lockingStartTime,
+                                                             testSetup.lockingEndTime,
+                                                             testSetup.extetnalTokenLockerMock.address,
+                                                             "lockedTokenBalances(address)");
+   }
 
    var permissions = "0x00000000";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.externalLocking4Reputation.address],[helpers.NULL_HASH],[permissions]);
@@ -32,7 +34,7 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
 };
 
 contract('ExternalLocking4Reputation', accounts => {
-    it("constructor", async () => {
+    it("setParameters", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.externalLocking4Reputation.reputationReward(),100);
       assert.equal(await testSetup.externalLocking4Reputation.lockingEndTime(),testSetup.lockingEndTime);
@@ -51,6 +53,16 @@ contract('ExternalLocking4Reputation', accounts => {
       assert.equal(tx.logs[0].args._amount,100);
       assert.equal(tx.logs[0].args._period,1);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
+    });
+
+    it("cannot lock before set parameters", async () => {
+      let testSetup = await setup(accounts,100,0,3000,false);
+      try {
+        await testSetup.externalLocking4Reputation.lock();
+        assert(false, "cannot lock before set parameters");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
     });
 
     it("lock with value == 0 should revert", async () => {
@@ -148,4 +160,43 @@ contract('ExternalLocking4Reputation', accounts => {
              helpers.assertVMException(error);
            }
     });
+
+    it("cannot setParameters twice", async () => {
+        let testSetup = await setup(accounts);
+        try {
+             await testSetup.externalLocking4Reputation.setParameters(testSetup.org.avatar.address,
+                                                                     100,
+                                                                     testSetup.lockingStartTime,
+                                                                     testSetup.lockingEndTime,
+                                                                     testSetup.extetnalTokenLockerMock.address,
+                                                                     "lockedTokenBalances(address)");
+             assert(false, "cannot setParameters twice");
+           } catch(error) {
+             helpers.assertVMException(error);
+           }
+    });
+
+    it("setParameters is onlyOwner", async () => {
+      var externalLocking4Reputation = await ExternalLocking4Reputation.new();
+      try {
+        await externalLocking4Reputation.setParameters(accounts[0],
+                                                       100,
+                                                       0,
+                                                       3000,
+                                                       accounts[0],
+                                                       "lockedTokenBalances(address)",
+                                              {from:accounts[1]});
+        assert(false, "setParameters is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+      await externalLocking4Reputation.setParameters(accounts[0],
+                                                     100,
+                                                     0,
+                                                     3000,
+                                                     accounts[0],
+                                                     "lockedTokenBalances(address)",
+                                                     {from:accounts[0]});
+    });
+
 });

--- a/test/fixreputationallocation.js
+++ b/test/fixreputationallocation.js
@@ -4,14 +4,17 @@ const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 const constants = require('./constants');
 var FixedReputationAllocation = artifacts.require("./FixedReputationAllocation.sol");
 
-const setup = async function (accounts,_repAllocation = 300) {
+const setup = async function (accounts,_repAllocation = 300,_setParameters = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],0,0);
 
-   testSetup.fixedReputationAllocation = await FixedReputationAllocation.new(testSetup.org.avatar.address,
-                                                                            _repAllocation);
+   testSetup.fixedReputationAllocation = await FixedReputationAllocation.new();
+   if (_setParameters ===  true) {
+    await testSetup.fixedReputationAllocation.setParameters(testSetup.org.avatar.address,
+                                                            _repAllocation);
+   }
 
    var permissions = "0x00000000";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.fixedReputationAllocation.address],[helpers.NULL_HASH],[permissions]);
@@ -19,7 +22,7 @@ const setup = async function (accounts,_repAllocation = 300) {
 };
 
 contract('FixedReputationAllocation', accounts => {
-    it("constructor", async () => {
+    it("setParameters", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.fixedReputationAllocation.reputationReward(),300);
       assert.equal(await testSetup.fixedReputationAllocation.isEnable(),false);
@@ -69,6 +72,21 @@ contract('FixedReputationAllocation', accounts => {
       }
     });
 
+    it("cannot redeem if not setParameters", async () => {
+      let testSetup = await setup(accounts,300,false);
+      await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
+      assert.equal(await testSetup.fixedReputationAllocation.numberOfBeneficiaries(),accounts.length);
+      assert.equal(await testSetup.fixedReputationAllocation.beneficiaryReward(),0);
+      await testSetup.fixedReputationAllocation.enable();
+      try {
+        await testSetup.fixedReputationAllocation.redeem(accounts[0]);
+        assert(false, "cannot redeem if not setParameters");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+    });
+
+
     it("redeem without enable should revert", async () => {
       let testSetup = await setup(accounts);
       await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
@@ -101,5 +119,31 @@ contract('FixedReputationAllocation', accounts => {
       } catch(error) {
         helpers.assertVMException(error);
       }
+    });
+
+    it("cannot setParameters twice", async () => {
+        let testSetup = await setup(accounts);
+        try {
+             await testSetup.fixedReputationAllocation.setParameters(testSetup.org.avatar.address,
+                                                                     100);
+             assert(false, "cannot setParameters twice");
+           } catch(error) {
+             helpers.assertVMException(error);
+           }
+    });
+
+    it("setParameters is onlyOwner", async () => {
+      var fixedReputationAllocation = await FixedReputationAllocation.new();
+      try {
+        await fixedReputationAllocation.setParameters(accounts[0],
+                                                       100,
+                                                       {from:accounts[1]});
+        assert(false, "setParameters is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+      await fixedReputationAllocation.setParameters(accounts[0],
+                                                     100,
+                                                     {from:accounts[0]});
     });
 });

--- a/test/fixreputationallocation.js
+++ b/test/fixreputationallocation.js
@@ -4,15 +4,15 @@ const ControllerCreator = artifacts.require("./ControllerCreator.sol");
 const constants = require('./constants');
 var FixedReputationAllocation = artifacts.require("./FixedReputationAllocation.sol");
 
-const setup = async function (accounts,_repAllocation = 300,_setParameters = true) {
+const setup = async function (accounts,_repAllocation = 300,_initialize = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],0,0);
 
    testSetup.fixedReputationAllocation = await FixedReputationAllocation.new();
-   if (_setParameters ===  true) {
-    await testSetup.fixedReputationAllocation.setParameters(testSetup.org.avatar.address,
+   if (_initialize ===  true) {
+    await testSetup.fixedReputationAllocation.initialize(testSetup.org.avatar.address,
                                                             _repAllocation);
    }
 
@@ -22,7 +22,7 @@ const setup = async function (accounts,_repAllocation = 300,_setParameters = tru
 };
 
 contract('FixedReputationAllocation', accounts => {
-    it("setParameters", async () => {
+    it("initialize", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.fixedReputationAllocation.reputationReward(),300);
       assert.equal(await testSetup.fixedReputationAllocation.isEnable(),false);
@@ -72,7 +72,7 @@ contract('FixedReputationAllocation', accounts => {
       }
     });
 
-    it("cannot redeem if not setParameters", async () => {
+    it("cannot redeem if not initialize", async () => {
       let testSetup = await setup(accounts,300,false);
       await testSetup.fixedReputationAllocation.addBeneficiaries(accounts);
       assert.equal(await testSetup.fixedReputationAllocation.numberOfBeneficiaries(),accounts.length);
@@ -80,7 +80,7 @@ contract('FixedReputationAllocation', accounts => {
       await testSetup.fixedReputationAllocation.enable();
       try {
         await testSetup.fixedReputationAllocation.redeem(accounts[0]);
-        assert(false, "cannot redeem if not setParameters");
+        assert(false, "cannot redeem if not initialize");
       } catch(error) {
         helpers.assertVMException(error);
       }
@@ -121,28 +121,28 @@ contract('FixedReputationAllocation', accounts => {
       }
     });
 
-    it("cannot setParameters twice", async () => {
+    it("cannot initialize twice", async () => {
         let testSetup = await setup(accounts);
         try {
-             await testSetup.fixedReputationAllocation.setParameters(testSetup.org.avatar.address,
+             await testSetup.fixedReputationAllocation.initialize(testSetup.org.avatar.address,
                                                                      100);
-             assert(false, "cannot setParameters twice");
+             assert(false, "cannot initialize twice");
            } catch(error) {
              helpers.assertVMException(error);
            }
     });
 
-    it("setParameters is onlyOwner", async () => {
+    it("initialize is onlyOwner", async () => {
       var fixedReputationAllocation = await FixedReputationAllocation.new();
       try {
-        await fixedReputationAllocation.setParameters(accounts[0],
+        await fixedReputationAllocation.initialize(accounts[0],
                                                        100,
                                                        {from:accounts[1]});
-        assert(false, "setParameters is onlyOwner");
+        assert(false, "initialize is onlyOwner");
       } catch(error) {
         helpers.assertVMException(error);
       }
-      await fixedReputationAllocation.setParameters(accounts[0],
+      await fixedReputationAllocation.initialize(accounts[0],
                                                      100,
                                                      {from:accounts[0]});
     });

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -10,7 +10,7 @@ const setup = async function (accounts,
                              _lockingStartTime = 0,
                              _lockingEndTime = 3000,
                              _maxLockingPeriod = 6000,
-                             _setParameters = true) {
+                             _initialize = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
@@ -18,8 +18,8 @@ const setup = async function (accounts,
    testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
    testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
    testSetup.lockingEth4Reputation = await LockingEth4Reputation.new();
-   if (_setParameters === true) {
-      await testSetup.lockingEth4Reputation.setParameters(testSetup.org.avatar.address,
+   if (_initialize === true) {
+      await testSetup.lockingEth4Reputation.initialize(testSetup.org.avatar.address,
                                                           _repAllocation,
                                                           testSetup.lockingStartTime,
                                                           testSetup.lockingEndTime,
@@ -33,7 +33,7 @@ const setup = async function (accounts,
 };
 
 contract('LockingEth4Reputation', accounts => {
-    it("setParameters", async () => {
+    it("initialize", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.lockingEth4Reputation.reputationReward(),100);
       assert.equal(await testSetup.lockingEth4Reputation.maxLockingPeriod(),6000);
@@ -52,11 +52,11 @@ contract('LockingEth4Reputation', accounts => {
       assert.equal(tx.logs[0].args._locker,accounts[0]);
     });
 
-    it("cannot lock without setParameters", async () => {
+    it("cannot lock without initialize", async () => {
       let testSetup = await setup(accounts,100,0,3000,6000,false);
       try {
         await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
-        assert(false, "cannot lock without setParameters");
+        assert(false, "cannot lock without initialize");
       } catch(error) {
         helpers.assertVMException(error);
       }
@@ -206,34 +206,34 @@ contract('LockingEth4Reputation', accounts => {
            }
     });
 
-    it("cannot setParameters twice", async () => {
+    it("cannot initialize twice", async () => {
         let testSetup = await setup(accounts);
         try {
-             await testSetup.lockingEth4Reputation.setParameters(testSetup.org.avatar.address,
+             await testSetup.lockingEth4Reputation.initialize(testSetup.org.avatar.address,
                                                                  100,
                                                                  testSetup.lockingStartTime,
                                                                  testSetup.lockingEndTime,
                                                                  6000);
-             assert(false, "cannot setParameters twice");
+             assert(false, "cannot initialize twice");
            } catch(error) {
              helpers.assertVMException(error);
            }
     });
 
-    it("setParameters is onlyOwner", async () => {
+    it("initialize is onlyOwner", async () => {
       var lockingEth4Reputation = await LockingEth4Reputation.new();
       try {
-        await lockingEth4Reputation.setParameters(accounts[1],
+        await lockingEth4Reputation.initialize(accounts[1],
                                                   100,
                                                   0,
                                                   100,
                                                   6000,
                                                 {from:accounts[1]});
-        assert(false, "setParameters is onlyOwner");
+        assert(false, "initialize is onlyOwner");
       } catch(error) {
         helpers.assertVMException(error);
       }
-      await lockingEth4Reputation.setParameters(accounts[1],
+      await lockingEth4Reputation.initialize(accounts[1],
                                                 100,
                                                 0,
                                                 100,

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -5,14 +5,27 @@ const constants = require('./constants');
 
 var LockingEth4Reputation = artifacts.require("./LockingEth4Reputation.sol");
 
-const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_maxLockingPeriod = 6000) {
+const setup = async function (accounts,
+                             _repAllocation = 100,
+                             _lockingStartTime = 0,
+                             _lockingEndTime = 3000,
+                             _maxLockingPeriod = 6000,
+                             _setParameters = true) {
    var testSetup = new helpers.TestSetup();
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
-   testSetup.lockingEth4Reputation = await LockingEth4Reputation.new(testSetup.org.avatar.address,_repAllocation,testSetup.lockingStartTime,testSetup.lockingEndTime,_maxLockingPeriod);
+   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingEth4Reputation = await LockingEth4Reputation.new();
+   if (_setParameters === true) {
+      await testSetup.lockingEth4Reputation.setParameters(testSetup.org.avatar.address,
+                                                          _repAllocation,
+                                                          testSetup.lockingStartTime,
+                                                          testSetup.lockingEndTime,
+                                                          _maxLockingPeriod);
+   }
+
 
    var permissions = "0x00000000";
    await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingEth4Reputation.address],[helpers.NULL_HASH],[permissions]);
@@ -20,7 +33,7 @@ const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 
 };
 
 contract('LockingEth4Reputation', accounts => {
-    it("constructor", async () => {
+    it("setParameters", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.lockingEth4Reputation.reputationReward(),100);
       assert.equal(await testSetup.lockingEth4Reputation.maxLockingPeriod(),6000);
@@ -37,6 +50,16 @@ contract('LockingEth4Reputation', accounts => {
       assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._period,100);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
+    });
+
+    it("cannot lock without setParameters", async () => {
+      let testSetup = await setup(accounts,100,0,3000,6000,false);
+      try {
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        assert(false, "cannot lock without setParameters");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
     });
 
     it("lock with value == 0 should revert", async () => {
@@ -181,5 +204,40 @@ contract('LockingEth4Reputation', accounts => {
            } catch(error) {
              helpers.assertVMException(error);
            }
+    });
+
+    it("cannot setParameters twice", async () => {
+        let testSetup = await setup(accounts);
+        try {
+             await testSetup.lockingEth4Reputation.setParameters(testSetup.org.avatar.address,
+                                                                 100,
+                                                                 testSetup.lockingStartTime,
+                                                                 testSetup.lockingEndTime,
+                                                                 6000);
+             assert(false, "cannot setParameters twice");
+           } catch(error) {
+             helpers.assertVMException(error);
+           }
+    });
+
+    it("setParameters is onlyOwner", async () => {
+      var lockingEth4Reputation = await LockingEth4Reputation.new();
+      try {
+        await lockingEth4Reputation.setParameters(accounts[1],
+                                                  100,
+                                                  0,
+                                                  100,
+                                                  6000,
+                                                {from:accounts[1]});
+        assert(false, "setParameters is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+      await lockingEth4Reputation.setParameters(accounts[1],
+                                                100,
+                                                0,
+                                                100,
+                                                6000,
+                                              {from:accounts[0]});
     });
 });

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -15,8 +15,8 @@ const setup = async function (accounts,
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
    testSetup.lockingEth4Reputation = await LockingEth4Reputation.new();
    if (_initialize === true) {
       await testSetup.lockingEth4Reputation.initialize(testSetup.org.avatar.address,
@@ -55,7 +55,7 @@ contract('LockingEth4Reputation', accounts => {
     it("cannot lock without initialize", async () => {
       let testSetup = await setup(accounts,100,0,3000,6000,false);
       try {
-        await testSetup.lockingEth4Reputation.lock(100,{value:web3.toWei('1', "ether")});
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         assert(false, "cannot lock without initialize");
       } catch(error) {
         helpers.assertVMException(error);

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -5,29 +5,37 @@ const constants = require('./constants');
 const StandardTokenMock = artifacts.require('./test/StandardTokenMock.sol');
 var LockingToken4Reputation = artifacts.require("./LockingToken4Reputation.sol");
 
-const setup = async function (accounts,_repAllocation = 100,_lockingStartTime = 0,_lockingEndTime = 3000,_maxLockingPeriod = 6000) {
+const setup = async function (accounts,
+                             _repAllocation = 100,
+                             _lockingStartTime = 0,
+                             _lockingEndTime = 3000,
+                             _maxLockingPeriod = 6000,
+                             _setParameters = true) {
    var testSetup = new helpers.TestSetup();
-   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.utils.toWei('100', "ether"));
+   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
-   testSetup.lockingToken4Reputation = await LockingToken4Reputation.new(testSetup.org.avatar.address,
-                                                                       _repAllocation,
-                                                                      testSetup.lockingStartTime,
-                                                                      testSetup.lockingEndTime,
-                                                                      _maxLockingPeriod,
-                                                                      testSetup.lockingToken.address);
+   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingToken4Reputation = await LockingToken4Reputation.new();
+   if (_setParameters === true) {
+      await testSetup.lockingToken4Reputation.setParameters(testSetup.org.avatar.address,
+                                                           _repAllocation,
+                                                           testSetup.lockingStartTime,
+                                                           testSetup.lockingEndTime,
+                                                           _maxLockingPeriod,
+                                                           testSetup.lockingToken.address);
+  }
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[helpers.NULL_HASH],[permissions]);
-   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"));
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[0],[permissions]);
+   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"));
    return testSetup;
 };
 
 contract('LockingToken4Reputation', accounts => {
-    it("constructor", async () => {
+    it("setParameters", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.lockingToken4Reputation.reputationReward(),100);
       assert.equal(await testSetup.lockingToken4Reputation.maxLockingPeriod(),6000);
@@ -37,20 +45,30 @@ contract('LockingToken4Reputation', accounts => {
 
     it("lock", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Lock");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._period,100);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
+    });
+
+    it("cannot lock without setParameters", async () => {
+      let testSetup = await setup(accounts,100,0,3000,6000,false);
+      try {
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        assert(false, "cannot lock without setParameters");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
     });
 
     it("lock with value == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('0', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('0', "ether"),100);
         assert(false, "lock with value == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -61,7 +79,7 @@ contract('LockingToken4Reputation', accounts => {
       let testSetup = await setup(accounts);
       await helpers.increaseTime(3001);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
         assert(false, "lock after _lockingEndTime should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -71,7 +89,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock before start should  revert", async () => {
       let testSetup = await setup(accounts,100,100);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
         assert(false, "lock before start should  revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -81,7 +99,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock with period == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
         assert(false, "lock with period == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -91,7 +109,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock over _maxLockingPeriod should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),6001);
+        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),6001);
         assert(false, "lock over _maxLockingPeriod should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -100,20 +118,20 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       await helpers.increaseTime(101);
       tx = await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Release");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._beneficiary,accounts[0]);
     });
 
     it("release before locking period should revert", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       try {
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -125,7 +143,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release cannot release twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(101);
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -139,7 +157,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         tx = await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -153,11 +171,11 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem score ", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100 ,{from:accounts[0]});
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100 ,{from:accounts[0]});
         var lockingId1 = await helpers.getValueFromLogs(tx, '_lockingId',1);
-        await testSetup.lockingToken.transfer(accounts[1],web3.utils.toWei('1', "ether"));
-        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"),{from:accounts[1]});
-        tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),300 ,{from:accounts[1]});
+        await testSetup.lockingToken.transfer(accounts[1],web3.toWei('1', "ether"));
+        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"),{from:accounts[1]});
+        tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),300 ,{from:accounts[1]});
         var lockingId2 = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId1);
@@ -168,7 +186,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem cannot redeem twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -182,7 +200,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem before lockingEndTime should revert", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(50);
         try {
@@ -191,5 +209,43 @@ contract('LockingToken4Reputation', accounts => {
            } catch(error) {
              helpers.assertVMException(error);
            }
+    });
+
+    it("cannot setParameters twice", async () => {
+        let testSetup = await setup(accounts);
+        try {
+             await testSetup.lockingToken4Reputation.setParameters(testSetup.org.avatar.address,
+                                                                  100,
+                                                                  testSetup.lockingStartTime,
+                                                                  testSetup.lockingEndTime,
+                                                                  6000,
+                                                                  testSetup.lockingToken.address);
+             assert(false, "cannot setParameters twice");
+           } catch(error) {
+             helpers.assertVMException(error);
+           }
+    });
+
+    it("setParameters is onlyOwner", async () => {
+      var lockingToken4Reputation = await LockingToken4Reputation.new();
+      try {
+        await lockingToken4Reputation.setParameters(accounts[1],
+                                                  100,
+                                                  0,
+                                                  100,
+                                                  6000,
+                                                  accounts[1],
+                                                {from:accounts[1]});
+        assert(false, "setParameters is onlyOwner");
+      } catch(error) {
+        helpers.assertVMException(error);
+      }
+      await lockingToken4Reputation.setParameters(accounts[1],
+                                                100,
+                                                0,
+                                                100,
+                                                6000,
+                                                accounts[1],
+                                                {from:accounts[0]});
     });
 });

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -10,7 +10,7 @@ const setup = async function (accounts,
                              _lockingStartTime = 0,
                              _lockingEndTime = 3000,
                              _maxLockingPeriod = 6000,
-                             _setParameters = true) {
+                             _initialize = true) {
    var testSetup = new helpers.TestSetup();
    testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
@@ -19,8 +19,8 @@ const setup = async function (accounts,
    testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
    testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
    testSetup.lockingToken4Reputation = await LockingToken4Reputation.new();
-   if (_setParameters === true) {
-      await testSetup.lockingToken4Reputation.setParameters(testSetup.org.avatar.address,
+   if (_initialize === true) {
+      await testSetup.lockingToken4Reputation.initialize(testSetup.org.avatar.address,
                                                            _repAllocation,
                                                            testSetup.lockingStartTime,
                                                            testSetup.lockingEndTime,
@@ -35,7 +35,7 @@ const setup = async function (accounts,
 };
 
 contract('LockingToken4Reputation', accounts => {
-    it("setParameters", async () => {
+    it("initialize", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.lockingToken4Reputation.reputationReward(),100);
       assert.equal(await testSetup.lockingToken4Reputation.maxLockingPeriod(),6000);
@@ -55,11 +55,11 @@ contract('LockingToken4Reputation', accounts => {
       assert.equal(tx.logs[0].args._locker,accounts[0]);
     });
 
-    it("cannot lock without setParameters", async () => {
+    it("cannot lock without initialize", async () => {
       let testSetup = await setup(accounts,100,0,3000,6000,false);
       try {
         await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
-        assert(false, "cannot lock without setParameters");
+        assert(false, "cannot lock without initialize");
       } catch(error) {
         helpers.assertVMException(error);
       }
@@ -211,36 +211,36 @@ contract('LockingToken4Reputation', accounts => {
            }
     });
 
-    it("cannot setParameters twice", async () => {
+    it("cannot initialize twice", async () => {
         let testSetup = await setup(accounts);
         try {
-             await testSetup.lockingToken4Reputation.setParameters(testSetup.org.avatar.address,
+             await testSetup.lockingToken4Reputation.initialize(testSetup.org.avatar.address,
                                                                   100,
                                                                   testSetup.lockingStartTime,
                                                                   testSetup.lockingEndTime,
                                                                   6000,
                                                                   testSetup.lockingToken.address);
-             assert(false, "cannot setParameters twice");
+             assert(false, "cannot initialize twice");
            } catch(error) {
              helpers.assertVMException(error);
            }
     });
 
-    it("setParameters is onlyOwner", async () => {
+    it("initialize is onlyOwner", async () => {
       var lockingToken4Reputation = await LockingToken4Reputation.new();
       try {
-        await lockingToken4Reputation.setParameters(accounts[1],
+        await lockingToken4Reputation.initialize(accounts[1],
                                                   100,
                                                   0,
                                                   100,
                                                   6000,
                                                   accounts[1],
                                                 {from:accounts[1]});
-        assert(false, "setParameters is onlyOwner");
+        assert(false, "initialize is onlyOwner");
       } catch(error) {
         helpers.assertVMException(error);
       }
-      await lockingToken4Reputation.setParameters(accounts[1],
+      await lockingToken4Reputation.initialize(accounts[1],
                                                 100,
                                                 0,
                                                 100,

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -12,12 +12,12 @@ const setup = async function (accounts,
                              _maxLockingPeriod = 6000,
                              _initialize = true) {
    var testSetup = new helpers.TestSetup();
-   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.toWei('100', "ether"));
+   testSetup.lockingToken = await StandardTokenMock.new(accounts[0], web3.utils.toWei('100', "ether"));
    var controllerCreator = await ControllerCreator.new({gas: constants.ARC_GAS_LIMIT});
    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address,{gas:constants.ARC_GAS_LIMIT});
    testSetup.org = await helpers.setupOrganization(testSetup.daoCreator,accounts[0],1000,1000);
-   testSetup.lockingEndTime = await web3.eth.getBlock("latest").timestamp + _lockingEndTime;
-   testSetup.lockingStartTime = await web3.eth.getBlock("latest").timestamp + _lockingStartTime;
+   testSetup.lockingEndTime = (await web3.eth.getBlock("latest")).timestamp + _lockingEndTime;
+   testSetup.lockingStartTime = (await web3.eth.getBlock("latest")).timestamp + _lockingStartTime;
    testSetup.lockingToken4Reputation = await LockingToken4Reputation.new();
    if (_initialize === true) {
       await testSetup.lockingToken4Reputation.initialize(testSetup.org.avatar.address,
@@ -29,8 +29,8 @@ const setup = async function (accounts,
   }
 
    var permissions = "0x00000000";
-   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[0],[permissions]);
-   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"));
+   await testSetup.daoCreator.setSchemes(testSetup.org.avatar.address,[testSetup.lockingToken4Reputation.address],[helpers.NULL_HASH],[permissions]);
+   await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"));
    return testSetup;
 };
 
@@ -45,12 +45,12 @@ contract('LockingToken4Reputation', accounts => {
 
     it("lock", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Lock");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._period,100);
       assert.equal(tx.logs[0].args._locker,accounts[0]);
     });
@@ -58,7 +58,7 @@ contract('LockingToken4Reputation', accounts => {
     it("cannot lock without initialize", async () => {
       let testSetup = await setup(accounts,100,0,3000,6000,false);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         assert(false, "cannot lock without initialize");
       } catch(error) {
         helpers.assertVMException(error);
@@ -68,7 +68,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock with value == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('0', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('0', "ether"),100);
         assert(false, "lock with value == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -79,7 +79,7 @@ contract('LockingToken4Reputation', accounts => {
       let testSetup = await setup(accounts);
       await helpers.increaseTime(3001);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         assert(false, "lock after _lockingEndTime should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -89,7 +89,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock before start should  revert", async () => {
       let testSetup = await setup(accounts,100,100);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
         assert(false, "lock before start should  revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -99,7 +99,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock with period == 0 should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),0);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),0);
         assert(false, "lock with period == 0 should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -109,7 +109,7 @@ contract('LockingToken4Reputation', accounts => {
     it("lock over _maxLockingPeriod should revert", async () => {
       let testSetup = await setup(accounts);
       try {
-        await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),6001);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),6001);
         assert(false, "lock over _maxLockingPeriod should revert");
       } catch(error) {
         helpers.assertVMException(error);
@@ -118,20 +118,20 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       await helpers.increaseTime(101);
       tx = await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
       assert.equal(tx.logs.length,1);
       assert.equal(tx.logs[0].event,"Release");
       assert.equal(tx.logs[0].args._lockingId,lockingId);
-      assert.equal(tx.logs[0].args._amount,web3.toWei('1', "ether"));
+      assert.equal(tx.logs[0].args._amount,web3.utils.toWei('1', "ether"));
       assert.equal(tx.logs[0].args._beneficiary,accounts[0]);
     });
 
     it("release before locking period should revert", async () => {
       let testSetup = await setup(accounts);
-      var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+      var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
       var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
       try {
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -143,7 +143,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("release cannot release twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(101);
         await testSetup.lockingToken4Reputation.release(accounts[0],lockingId);
@@ -157,7 +157,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         tx = await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -171,11 +171,11 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem score ", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100 ,{from:accounts[0]});
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100 ,{from:accounts[0]});
         var lockingId1 = await helpers.getValueFromLogs(tx, '_lockingId',1);
-        await testSetup.lockingToken.transfer(accounts[1],web3.toWei('1', "ether"));
-        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.toWei('100', "ether"),{from:accounts[1]});
-        tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),300 ,{from:accounts[1]});
+        await testSetup.lockingToken.transfer(accounts[1],web3.utils.toWei('1', "ether"));
+        await testSetup.lockingToken.approve(testSetup.lockingToken4Reputation.address,web3.utils.toWei('100', "ether"),{from:accounts[1]});
+        tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),300 ,{from:accounts[1]});
         var lockingId2 = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId1);
@@ -186,7 +186,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem cannot redeem twice", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0],lockingId);
@@ -200,7 +200,7 @@ contract('LockingToken4Reputation', accounts => {
 
     it("redeem before lockingEndTime should revert", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.lockingToken4Reputation.lock(web3.toWei('1', "ether"),100);
+        var tx = await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100);
         var lockingId = await helpers.getValueFromLogs(tx, '_lockingId',1);
         await helpers.increaseTime(50);
         try {


### PR DESCRIPTION
Add one time ,onlyOwner , initialiser (setParameters) to ease the deployment processes for the following schemes: 

- Auction4Reputation
- ExternalLocking4Reputation
- FixReputationAllocation
- LockingEth4Reputation
- LockingToken4Reputation

 