### PR TITLE
ExternalLocking4Rep : add registrar

### DIFF
--- a/contracts/schemes/ExternalLocking4Reputation.sol
+++ b/contracts/schemes/ExternalLocking4Reputation.sol
@@ -10,20 +10,24 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ExternalLocking4Reputation is Locking4Reputation, Ownable {
 
+    event Register(address indexed _beneficiary);
+
     address public externalLockingContract;
     string public getBalanceFuncSignature;
 
     // locker -> bool
     mapping(address => bool) public externalLockers;
+    //      beneficiary -> bool
+    mapping(address     => bool) public registrar;
 
     /**
      * @dev initialize
      * @param _avatar the avatar to mint reputation from
      * @param _reputationReward the total reputation this contract will reward
      *        for the token locking
-     * @param _lockingStartTime locking starting period time.
-     * @param _lockingEndTime the locking end time.
-     *        locking is disable after this time.
+     * @param _claimingStartTime claiming starting period time.
+     * @param _claimingEndTime the claiming end time.
+     *        claiming is disable after this time.
      * @param _redeemEnableTime redeem enable time .
      *        redeem reputation can be done after this time.
      * @param _externalLockingContract the contract which lock the token.
@@ -33,36 +37,45 @@ contract ExternalLocking4Reputation is Locking4Reputation, Ownable {
     function initialize(
         Avatar _avatar,
         uint _reputationReward,
-        uint _lockingStartTime,
-        uint _lockingEndTime,
+        uint _claimingStartTime,
+        uint _claimingEndTime,
         uint _redeemEnableTime,
         address _externalLockingContract,
         string _getBalanceFuncSignature)
     external
     onlyOwner
     {
-        require(_lockingEndTime > _lockingStartTime, "_lockingEndTime should be greater than _lockingStartTime");
+        require(_claimingEndTime > _claimingStartTime, "_claimingEndTime should be greater than _claimingStartTime");
         externalLockingContract = _externalLockingContract;
         getBalanceFuncSignature = _getBalanceFuncSignature;
         super._initialize(
         _avatar,
         _reputationReward,
-        _lockingStartTime,
-        _lockingEndTime,
+        _claimingStartTime,
+        _claimingEndTime,
         _redeemEnableTime,
         1);
     }
 
     /**
-     * @dev lock function
-     * @return lockingId
+     * @dev claim function
+     * @param _beneficiary the beneficiary address to claim for
+     *        if _beneficiary == 0 the claim will be for the msg.sender.
+     * @return claimId
      */
-    function lock() public returns(bytes32) {
+    function claim(address _beneficiary) public returns(bytes32) {
         require(avatar != Avatar(0), "should initialize first");
-        require(externalLockers[msg.sender] == false, "locking twice is not allowed");
-        externalLockers[msg.sender] = true;
+        address beneficiary;
+        if (_beneficiary == address(0)) {
+            beneficiary = msg.sender;
+        } else {
+            require(registrar[_beneficiary],"beneficiary should be register");
+            beneficiary = _beneficiary;
+        }
+        require(externalLockers[beneficiary] == false, "claiming twice is not allowed");
+        externalLockers[beneficiary] = true;
         // solium-disable-next-line security/no-low-level-calls
-        bool result = externalLockingContract.call(abi.encodeWithSignature(getBalanceFuncSignature, msg.sender));
+        bool result = externalLockingContract.call(abi.encodeWithSignature(getBalanceFuncSignature, beneficiary));
         uint lockedAmount;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
@@ -73,6 +86,15 @@ contract ExternalLocking4Reputation is Locking4Reputation, Ownable {
           default { lockedAmount := mload(0) }
         }
 
-        return super._lock(lockedAmount, 1, msg.sender);
+        return super._lock(lockedAmount, 1, beneficiary);
+    }
+
+  /**
+    * @dev register function
+    *      register for external locking claim
+    */
+    function register() public {
+        registrar[msg.sender] = true;
+        emit Register(msg.sender);
     }
 }


### PR DESCRIPTION
- rename lock  to claim .

- claiming can be done for behalf of someone else only if it is register .

- add register function.