### PR TITLE
return reputation rewarded from Redeem function

### DIFF
--- a/contracts/schemes/Auction4Reputation.sol
+++ b/contracts/schemes/Auction4Reputation.sol
@@ -88,7 +88,7 @@ contract Auction4Reputation is Ownable {
      * @param _auctionId the auction id to redeem from.
      * @return uint reputation rewarded
      */
-    function redeem(address _beneficiary, uint _auctionId) public returns(uint) {
+    function redeem(address _beneficiary, uint _auctionId) public returns(uint reputation) {
         // solium-disable-next-line security/no-block-members
         require(now > redeemEnableTime, "now > redeemEnableTime");
         Auction storage auction = auctions[_auctionId];
@@ -96,12 +96,11 @@ contract Auction4Reputation is Ownable {
         require(bid > 0, "bidding amount should be > 0");
         auction.bids[_beneficiary] = 0;
         int256 repRelation = int216(bid).toReal().mul(int216(auctionReputationReward).toReal());
-        uint reputation = uint256(repRelation.div(int216(auction.totalBid).toReal()).fromReal());
+        reputation = uint256(repRelation.div(int216(auction.totalBid).toReal()).fromReal());
         // check that the reputation is sum zero
         reputationRewardLeft = reputationRewardLeft.sub(reputation);
         require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
         emit Redeem(_auctionId, _beneficiary, reputation);
-        return reputation;
     }
 
     /**

--- a/contracts/schemes/Auction4Reputation.sol
+++ b/contracts/schemes/Auction4Reputation.sol
@@ -86,9 +86,9 @@ contract Auction4Reputation is Ownable {
      * @dev redeem reputation function
      * @param _beneficiary the beneficiary to redeem.
      * @param _auctionId the auction id to redeem from.
-     * @return bool
+     * @return uint reputation rewarded
      */
-    function redeem(address _beneficiary, uint _auctionId) public returns(bool) {
+    function redeem(address _beneficiary, uint _auctionId) public returns(uint) {
         // solium-disable-next-line security/no-block-members
         require(now > redeemEnableTime, "now > redeemEnableTime");
         Auction storage auction = auctions[_auctionId];
@@ -101,7 +101,7 @@ contract Auction4Reputation is Ownable {
         reputationRewardLeft = reputationRewardLeft.sub(reputation);
         require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
         emit Redeem(_auctionId, _beneficiary, reputation);
-        return true;
+        return reputation;
     }
 
     /**

--- a/contracts/schemes/Locking4Reputation.sol
+++ b/contracts/schemes/Locking4Reputation.sol
@@ -43,9 +43,9 @@ contract Locking4Reputation {
     /**
      * @dev redeem reputation function
      * @param _beneficiary the beneficiary for the release
-     * @return bool
+     * @return uint reputation rewarded
      */
-    function redeem(address _beneficiary) public returns(bool) {
+    function redeem(address _beneficiary) public returns(uint) {
         // solium-disable-next-line security/no-block-members
         require(block.timestamp > redeemEnableTime, "now > redeemEnableTime");
         require(scores[_beneficiary] > 0, "score should be > 0");
@@ -60,7 +60,7 @@ contract Locking4Reputation {
 
         emit Redeem(_beneficiary, reputation);
 
-        return true;
+        return reputation;
     }
 
     /**

--- a/contracts/schemes/Locking4Reputation.sol
+++ b/contracts/schemes/Locking4Reputation.sol
@@ -45,22 +45,20 @@ contract Locking4Reputation {
      * @param _beneficiary the beneficiary for the release
      * @return uint reputation rewarded
      */
-    function redeem(address _beneficiary) public returns(uint) {
+    function redeem(address _beneficiary) public returns(uint reputation) {
         // solium-disable-next-line security/no-block-members
         require(block.timestamp > redeemEnableTime, "now > redeemEnableTime");
         require(scores[_beneficiary] > 0, "score should be > 0");
         uint score = scores[_beneficiary];
         scores[_beneficiary] = 0;
         int256 repRelation = int216(score).toReal().mul(int216(reputationReward).toReal());
-        uint reputation = uint256(repRelation.div(int216(totalScore).toReal()).fromReal());
+        reputation = uint256(repRelation.div(int216(totalScore).toReal()).fromReal());
 
         //check that the reputation is sum zero
         reputationRewardLeft = reputationRewardLeft.sub(reputation);
         require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
 
         emit Redeem(_beneficiary, reputation);
-
-        return reputation;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.0-alpha.57",
+  "version": "0.0.0-alpha.58",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.0-alpha.58",
+  "version": "0.0.0-alpha.57",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",

--- a/test/auction4reputation.js
+++ b/test/auction4reputation.js
@@ -337,4 +337,15 @@ contract('Auction4Reputation', accounts => {
              helpers.assertVMException(error);
            }
     });
+
+    it("get earned reputation", async () => {
+        let testSetup = await setup(accounts);
+        var tx = await testSetup.auction4Reputation.bid(web3.utils.toWei('1', "ether"));
+        var id = await helpers.getValueFromLogs(tx, '_auctionId',1);
+        await helpers.increaseTime(3001);
+        tx = await testSetup.auction4Reputation.redeem.call(accounts[0],id);
+        const reputation = await testSetup.auction4Reputation.redeem.call(accounts[0], id);
+        assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
 });

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -268,7 +268,7 @@ contract('ExternalLocking4Reputation', accounts => {
 
     it("get earned reputation", async () => {
         let testSetup = await setup(accounts);
-        var tx = await testSetup.externalLocking4Reputation.claim(helpers.NULL_ADDRESS);
+        await testSetup.externalLocking4Reputation.claim(helpers.NULL_ADDRESS);
         await helpers.increaseTime(3001);
         const reputation = await testSetup.externalLocking4Reputation.redeem.call(accounts[0]);
         assert.equal(reputation,100);

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -266,4 +266,12 @@ contract('ExternalLocking4Reputation', accounts => {
                                                      {from:accounts[0]});
     });
 
+    it("get earned reputation", async () => {
+        let testSetup = await setup(accounts);
+        var tx = await testSetup.externalLocking4Reputation.claim(helpers.NULL_ADDRESS);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.externalLocking4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
 });

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -281,4 +281,13 @@ contract('LockingEth4Reputation', accounts => {
                                                 100,
                                                 6000);
     });
+
+    it("get earned reputation", async () => {
+        let testSetup = await setup(accounts);
+        await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.lockingEth4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
 });

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -45,6 +45,15 @@ const setup = async function (accounts,
 };
 
 contract('LockingToken4Reputation', accounts => {
+    it("get earned reputation", async () => {
+        let testSetup = await setup(accounts);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100,testSetup.lockingToken.address);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.lockingToken4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
+
     it("initialize", async () => {
       let testSetup = await setup(accounts);
       assert.equal(await testSetup.lockingToken4Reputation.reputationReward(),100);
@@ -324,5 +333,14 @@ contract('LockingToken4Reputation', accounts => {
                                                 100,
                                                 6000,
                                                 accounts[1]);
+    });
+
+    it("get earned reputation", async () => {
+        let testSetup = await setup(accounts);
+        await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100,testSetup.lockingToken.address);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.lockingToken4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
     });
 });


### PR DESCRIPTION
The dutchx app wants to display to the user how much reputation the user will be rewarded.  This PR change greatly facilitates obtaining this value after the locking period has ended and before the rep has been redeemed, and it keeps within the contract the logic for computing reputation.

(The amount of reputation rewarded after redeeming will have to come from the Redeem events.)