### PR TITLE
redeem do nothing, return zero when no score/bid

### DIFF
--- a/contracts/schemes/Auction4Reputation.sol
+++ b/contracts/schemes/Auction4Reputation.sol
@@ -93,14 +93,17 @@ contract Auction4Reputation is Ownable {
         require(now > redeemEnableTime, "now > redeemEnableTime");
         Auction storage auction = auctions[_auctionId];
         uint bid = auction.bids[_beneficiary];
-        require(bid > 0, "bidding amount should be > 0");
-        auction.bids[_beneficiary] = 0;
-        int256 repRelation = int216(bid).toReal().mul(int216(auctionReputationReward).toReal());
-        reputation = uint256(repRelation.div(int216(auction.totalBid).toReal()).fromReal());
-        // check that the reputation is sum zero
-        reputationRewardLeft = reputationRewardLeft.sub(reputation);
-        require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
-        emit Redeem(_auctionId, _beneficiary, reputation);
+        if (bid <= 0) {
+            reputation = 0;
+        } else {
+            auction.bids[_beneficiary] = 0;
+            int256 repRelation = int216(bid).toReal().mul(int216(auctionReputationReward).toReal());
+            reputation = uint256(repRelation.div(int216(auction.totalBid).toReal()).fromReal());
+            // check that the reputation is sum zero
+            reputationRewardLeft = reputationRewardLeft.sub(reputation);
+            require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
+            emit Redeem(_auctionId, _beneficiary, reputation);
+        }
     }
 
     /**

--- a/contracts/schemes/Locking4Reputation.sol
+++ b/contracts/schemes/Locking4Reputation.sol
@@ -48,17 +48,20 @@ contract Locking4Reputation {
     function redeem(address _beneficiary) public returns(uint reputation) {
         // solium-disable-next-line security/no-block-members
         require(block.timestamp > redeemEnableTime, "now > redeemEnableTime");
-        require(scores[_beneficiary] > 0, "score should be > 0");
         uint score = scores[_beneficiary];
-        scores[_beneficiary] = 0;
-        int256 repRelation = int216(score).toReal().mul(int216(reputationReward).toReal());
-        reputation = uint256(repRelation.div(int216(totalScore).toReal()).fromReal());
+        if (score <= 0) {
+            reputation = 0;
+        } else {
+            scores[_beneficiary] = 0;
+            int256 repRelation = int216(score).toReal().mul(int216(reputationReward).toReal());
+            reputation = uint256(repRelation.div(int216(totalScore).toReal()).fromReal());
 
-        //check that the reputation is sum zero
-        reputationRewardLeft = reputationRewardLeft.sub(reputation);
-        require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
+            //check that the reputation is sum zero
+            reputationRewardLeft = reputationRewardLeft.sub(reputation);
+            require(ControllerInterface(avatar.owner()).mintReputation(reputation, _beneficiary, avatar), "mint reputation should success");
 
-        emit Redeem(_beneficiary, reputation);
+            emit Redeem(_beneficiary, reputation);
+        }
     }
 
     /**

--- a/test/auction4reputation.js
+++ b/test/auction4reputation.js
@@ -248,12 +248,9 @@ contract('Auction4Reputation', accounts => {
         var id = await helpers.getValueFromLogs(tx, '_auctionId',1);
         await helpers.increaseTime(3001);
         await testSetup.auction4Reputation.redeem(accounts[0],id);
-        try {
-          await testSetup.auction4Reputation.redeem(accounts[0],id);
-          assert(false, "cannot redeem twice");
-        } catch(error) {
-          helpers.assertVMException(error);
-        }
+        tx = await testSetup.auction4Reputation.redeem(accounts[0],id);
+        assert.equal(tx.logs.length,0);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000+100);
     });
 
     it("redeem before auctionEndTime should revert", async () => {
@@ -346,6 +343,19 @@ contract('Auction4Reputation', accounts => {
         tx = await testSetup.auction4Reputation.redeem.call(accounts[0],id);
         const reputation = await testSetup.auction4Reputation.redeem.call(accounts[0], id);
         assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
+
+    it("get earned reputation with zero score returns zero", async () => {
+        let testSetup = await setup(accounts);
+        await testSetup.biddingToken.transfer(accounts[1],web3.utils.toWei('3', "ether"));
+        await testSetup.biddingToken.approve(testSetup.auction4Reputation.address,web3.utils.toWei('100', "ether"),{from:accounts[1]});
+        let tx = await testSetup.auction4Reputation.bid(web3.utils.toWei('3', "ether"),{from:accounts[1]});
+        var id = await helpers.getValueFromLogs(tx, '_auctionId',1);
+        await helpers.increaseTime(3001);
+        await testSetup.auction4Reputation.redeem.call(accounts[0],id);
+        const reputation = await testSetup.auction4Reputation.redeem.call(accounts[0], id);
+        assert.equal(reputation,0);
         assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
     });
 });

--- a/test/externallocking4reputation.js
+++ b/test/externallocking4reputation.js
@@ -165,12 +165,9 @@ contract('ExternalLocking4Reputation', accounts => {
         await testSetup.externalLocking4Reputation.claim(helpers.NULL_ADDRESS);
         await helpers.increaseTime(3001);
         await testSetup.externalLocking4Reputation.redeem(accounts[0]);
-        try {
-          await testSetup.externalLocking4Reputation.redeem(accounts[0]);
-          assert(false, "cannot redeem twice");
-        } catch(error) {
-          helpers.assertVMException(error);
-        }
+        let tx = await testSetup.externalLocking4Reputation.redeem(accounts[0]);
+        assert.equal(tx.logs.length,0);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000+100);
     });
 
     it("redeem before lockingEndTime should revert", async () => {
@@ -272,6 +269,14 @@ contract('ExternalLocking4Reputation', accounts => {
         await helpers.increaseTime(3001);
         const reputation = await testSetup.externalLocking4Reputation.redeem.call(accounts[0]);
         assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
+
+    it("get earned reputation with zero score returns zero", async () => {
+        let testSetup = await setup(accounts);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.externalLocking4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,0);
         assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
     });
 });

--- a/test/lockingeth4reputation.js
+++ b/test/lockingeth4reputation.js
@@ -189,12 +189,9 @@ contract('LockingEth4Reputation', accounts => {
         await testSetup.lockingEth4Reputation.lock(100,{value:web3.utils.toWei('1', "ether")});
         await helpers.increaseTime(3001);
         await testSetup.lockingEth4Reputation.redeem(accounts[0]);
-        try {
-          await testSetup.lockingEth4Reputation.redeem(accounts[0]);
-          assert(false, "cannot redeem twice");
-        } catch(error) {
-          helpers.assertVMException(error);
-        }
+        let tx = await testSetup.lockingEth4Reputation.redeem(accounts[0]);
+        assert.equal(tx.logs.length,0);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000+100);
     });
 
     it("redeem before lockingEndTime should revert", async () => {
@@ -288,6 +285,14 @@ contract('LockingEth4Reputation', accounts => {
         await helpers.increaseTime(3001);
         const reputation = await testSetup.lockingEth4Reputation.redeem.call(accounts[0]);
         assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
+
+    it("get earned reputation with zero score returns zero", async () => {
+        let testSetup = await setup(accounts);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.lockingEth4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,0);
         assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
     });
 });

--- a/test/lockingtoken4reputation.js
+++ b/test/lockingtoken4reputation.js
@@ -206,7 +206,6 @@ contract('LockingToken4Reputation', accounts => {
           helpers.assertVMException(error);
         }
     });
-
     it("redeem", async () => {
         let testSetup = await setup(accounts);
         await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100,testSetup.lockingToken.address);
@@ -237,12 +236,9 @@ contract('LockingToken4Reputation', accounts => {
         await testSetup.lockingToken4Reputation.lock(web3.utils.toWei('1', "ether"),100,testSetup.lockingToken.address);
         await helpers.increaseTime(3001);
         await testSetup.lockingToken4Reputation.redeem(accounts[0]);
-        try {
-          await testSetup.lockingToken4Reputation.redeem(accounts[0]);
-          assert(false, "cannot redeem twice");
-        } catch(error) {
-          helpers.assertVMException(error);
-        }
+        let tx = await testSetup.lockingToken4Reputation.redeem(accounts[0]);
+        assert.equal(tx.logs.length,0);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000+100);
     });
 
     it("redeem before lockingEndTime should revert", async () => {
@@ -341,6 +337,14 @@ contract('LockingToken4Reputation', accounts => {
         await helpers.increaseTime(3001);
         const reputation = await testSetup.lockingToken4Reputation.redeem.call(accounts[0]);
         assert.equal(reputation,100);
+        assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
+    });
+
+    it("get earned reputation with zero score returns zero", async () => {
+        let testSetup = await setup(accounts);
+        await helpers.increaseTime(3001);
+        const reputation = await testSetup.lockingToken4Reputation.redeem.call(accounts[0]);
+        assert.equal(reputation,0);
         assert.equal(await testSetup.org.reputation.balanceOf(accounts[0]),1000);
     });
 });


### PR DESCRIPTION
It is a pretty big pain to code around that the reputation bootstrapping contracts `redeem` function reverts when score or bid are > zero.  Is there a realy need to revert in that case?

This PR changes the behavior to do nothing and return 0 when redeem is attempted with no score or bid.