### PR TITLE
StateManager first draft

### DIFF
--- a/contracts/universalSchemes/StateManager.sol
+++ b/contracts/universalSchemes/StateManager.sol
@@ -1,0 +1,150 @@
+pragma solidity ^0.5.11;
+
+import "@daostack/infra/contracts/votingMachines/IntVoteInterface.sol";
+import "@daostack/infra/contracts/votingMachines/VotingMachineCallbacksInterface.sol";
+import "./UniversalScheme.sol";
+import "../votingMachines/VotingMachineCallbacks.sol";
+
+/**
+ * @title A scheme for recording links to arbitrary states
+ * the DAO wants to track.
+ * @dev An agent can ask an organization to record a string/string
+ * pair naming and linking to some data.
+ */
+
+contract StateManager is UniversalScheme, VotingMachineCallbacks, ProposalExecuteInterface {
+    using SafeMath for uint;
+
+    event NewStateProposal(
+        address indexed _avatar,
+        bytes32 indexed _proposalId,
+        address indexed _intVoteInterface,
+        string _descriptionHash,
+        string name
+    );
+
+    event ProposalExecuted(address indexed _avatar, bytes32 indexed _proposalId, int256 _param);
+
+    // A struct holding the data for a state management proposal
+    struct StateProposal {
+        string name;
+        string data;
+        uint256 periodLength;
+        uint256 numberOfPeriods;
+        uint256 executionTime;
+    }
+
+    // A mapping from organization (Avatar) addresses to mappings of saved proposal data:
+    mapping(address=>mapping(bytes32=>StateProposal)) public stateProposals;
+
+    // A mapping from hashes to parameters (use to store a particular configuration on the controller)
+    struct Parameters {
+        bytes32 voteApproveParams;
+        IntVoteInterface intVote;
+    }
+
+    mapping(bytes32=>Parameters) public parameters;
+
+    // the STATE! a mapping from organization (Avatar) addresses to mappings of state names to states:
+    mapping(address=>mapping(string=>string)) public states;
+
+    /**
+    * @dev execution of proposals, can only be called by the voting machine in which the vote is held.
+    * @param _proposalId the ID of the voting in the voting machine
+    * @param _param a parameter of the voting result, 1 is yes and 2 is no.
+    */
+    function executeProposal(bytes32 _proposalId, int256 _param) external onlyVotingMachine(_proposalId) returns(bool) {
+        ProposalInfo memory proposal = proposalsInfo[msg.sender][_proposalId];
+        require(stateProposals[address(proposal.avatar)][_proposalId].executionTime == 0);
+        // Check if vote was successful:
+        if (_param == 1) {
+            stateProposals[address(proposal.avatar)][_proposalId].executionTime = now;
+            states[address(proposal.avatar)][stateProposals[address(proposal.avatar)][_proposalId].name] 
+                = stateProposals[address(proposal.avatar)][_proposalId].data;
+        }
+        emit ProposalExecuted(address(proposal.avatar), _proposalId, _param);
+        return true;
+    }
+
+    /**
+    * @dev hash the parameters, save them if necessary, and return the hash value
+    */
+    function setParameters(
+        bytes32 _voteApproveParams,
+        IntVoteInterface _intVote
+    ) public returns(bytes32)
+    {
+        bytes32 paramsHash = getParametersHash(
+            _voteApproveParams,
+            _intVote
+        );
+        parameters[paramsHash].voteApproveParams = _voteApproveParams;
+        parameters[paramsHash].intVote = _intVote;
+        return paramsHash;
+    }
+
+    /**
+    * @dev Submit a proposal for a reward for a contribution:
+    * @param _avatar Avatar of the organization that the contribution was made for
+    * @param _descriptionHash A hash of the proposal's description
+    */
+    function proposeStateChange(
+        Avatar _avatar, 
+        string memory _descriptionHash,
+        string memory name,
+        string memory data
+    ) public returns(bytes32) 
+    {
+        // validateProposalParams(_reputationChange, _rewards);
+        Parameters memory controllerParams = parameters[getParametersFromController(_avatar)];
+
+        bytes32 proposalId = controllerParams.intVote.propose(
+            2,
+            controllerParams.voteApproveParams,
+            msg.sender,
+            address(_avatar)
+        );
+
+        StateProposal memory proposal = StateProposal({
+            name: name,
+            data: data,
+            periodLength: 1,
+            numberOfPeriods: 1,
+            executionTime: 0
+        });
+        stateProposals[address(_avatar)][proposalId] = proposal;
+
+        emit NewStateProposal(
+            address(_avatar),
+            proposalId,
+            address(controllerParams.intVote),
+            _descriptionHash,
+            name
+        );
+
+        proposalsInfo[address(controllerParams.intVote)][proposalId] = ProposalInfo({
+            blockNumber: block.number,
+            avatar: _avatar
+        });
+        return proposalId;
+    }
+
+    function getProposalExecutionTime(bytes32 _proposalId, address _avatar) public view returns (uint256) {
+        return stateProposals[_avatar][_proposalId].executionTime;
+    }
+
+    /**
+    * @dev return a hash of the given parameters
+    * @param _voteApproveParams parameters for the voting machine used to approve a contribution
+    * @param _intVote the voting machine used to approve a contribution
+    * @return a hash of the parameters
+    */
+    function getParametersHash(
+        bytes32 _voteApproveParams,
+        IntVoteInterface _intVote
+    ) public pure returns(bytes32)
+    {
+        return (keccak256(abi.encodePacked(_voteApproveParams, _intVote)));
+    }
+
+}

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -7,6 +7,7 @@ var GlobalConstraintRegistrar = artifacts.require('./GlobalConstraintRegistrar.s
 var SchemeRegistrar = artifacts.require('./SchemeRegistrar.sol');
 var AbsoluteVote = artifacts.require('./AbsoluteVote.sol');
 var ContributionReward = artifacts.require('./ContributionReward.sol');
+var StateManager = artifacts.require('./StateManager.sol')
 var UpgradeScheme = artifacts.require('./UpgradeScheme.sol');
 var ControllerCreator = artifacts.require('./ControllerCreator.sol');
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -61,6 +62,9 @@ module.exports = async function(deployer) {
       await deployer.deploy(ContributionReward);
       var contributionRewardInst = await ContributionReward.deployed();
 
+      await deployer.deploy(StateManager);
+      var stateManagerInst = await StateManager.deployed();
+
       // Voting parameters and schemes params:
       var voteParametersHash = await AbsoluteVoteInst.getParametersHash(votePrec, NULL_ADDRESS);
 
@@ -74,11 +78,20 @@ module.exports = async function(deployer) {
       await contributionRewardInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
       var contributionRewardParams = await contributionRewardInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address);
 
+      await stateManagerInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
+      var stateManagerParams = await stateManagerInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address)
+
       var schemesArray = [schemeRegistrarInst.address,
                           globalConstraintRegistrarInst.address,
                           upgradeSchemeInst.address,
                           contributionRewardInst.address];
-      const paramsArray = [schemeRegisterParams, schemeGCRegisterParams, schemeUpgradeParams,contributionRewardParams];
+      const paramsArray = [
+          schemeRegisterParams, 
+          schemeGCRegisterParams, 
+          schemeUpgradeParams, 
+          contributionRewardParams, 
+          stateManagerParams
+      ];
       const permissionArray = ['0x0000001F', '0x00000005', '0x0000000a','0x00000001'];
 
       // set DAOstack initial schmes:

--- a/test/statemanager.js
+++ b/test/statemanager.js
@@ -4,8 +4,6 @@ const StateManager = artifacts.require("./StateManager.sol");
 const ERC20Mock = artifacts.require('./test/ERC20Mock.sol');
 const DaoCreator = artifacts.require("./DaoCreator.sol");
 const ControllerCreator = artifacts.require("./ControllerCreator.sol");
-const Avatar = artifacts.require("./Avatar.sol");
-const Redeemer = artifacts.require("./Redeemer.sol");
 
 export class StateManagerParams {
     constructor() {

--- a/test/statemanager.js
+++ b/test/statemanager.js
@@ -1,0 +1,126 @@
+import * as helpers from './helpers';
+const constants = require('./constants');
+const StateManager = artifacts.require("./StateManager.sol");
+const ERC20Mock = artifacts.require('./test/ERC20Mock.sol');
+const DaoCreator = artifacts.require("./DaoCreator.sol");
+const ControllerCreator = artifacts.require("./ControllerCreator.sol");
+const Avatar = artifacts.require("./Avatar.sol");
+const Redeemer = artifacts.require("./Redeemer.sol");
+
+export class StateManagerParams {
+    constructor() {
+    }
+}
+
+const setupStateManagerParams = async function (
+    stateManager,
+    accounts,
+    genesisProtocol,
+    token,
+    avatar
+) {
+    var stateManagerParams = new StateManagerParams();
+    if (genesisProtocol === true) {
+        stateManagerParams.votingMachine = await helpers.setupGenesisProtocol(accounts, token, avatar, helpers.NULL_ADDRESS);
+        await stateManager.setParameters(
+            stateManagerParams.votingMachine.params,
+            stateManagerParams.votingMachine.genesisProtocol.address);
+        stateManagerParams.paramsHash = await stateManager.getParametersHash(
+            stateManagerParams.votingMachine.params,
+            stateManagerParams.votingMachine.genesisProtocol.address);
+    } else {
+        stateManagerParams.votingMachine = await helpers.setupAbsoluteVote(helpers.NULL_ADDRESS, 50, stateManager.address);
+        await stateManager.setParameters(
+            stateManagerParams.votingMachine.params,
+            stateManagerParams.votingMachine.absoluteVote.address);
+        stateManagerParams.paramsHash = await stateManager.getParametersHash(
+            stateManagerParams.votingMachine.params,
+            stateManagerParams.votingMachine.absoluteVote.address);
+    }
+    return stateManagerParams;
+};
+
+const setup = async function (accounts, genesisProtocol = false, tokenAddress = 0) {
+    var testSetup = new helpers.TestSetup();
+    testSetup.standardTokenMock = await ERC20Mock.new(accounts[1], 100);
+    testSetup.stateManager = await StateManager.new();
+    var controllerCreator = await ControllerCreator.new({ gas: constants.ARC_GAS_LIMIT });
+    testSetup.daoCreator = await DaoCreator.new(controllerCreator.address, { gas: constants.ARC_GAS_LIMIT });
+    if (genesisProtocol) {
+        testSetup.reputationArray = [1000, 100, 0];
+    } else {
+        testSetup.reputationArray = [2000, 4000, 7000];
+    }
+    testSetup.org = await helpers.setupOrganizationWithArrays(testSetup.daoCreator, [accounts[0], accounts[1], accounts[2]], [1000, 0, 0], testSetup.reputationArray);
+    testSetup.stateManagerParams = await setupStateManagerParams(
+            testSetup.stateManager,
+            accounts, genesisProtocol,
+            tokenAddress,
+            testSetup.org.avatar
+        );
+    var permissions = "0x00000000";
+    await testSetup.daoCreator.setSchemes(
+        testSetup.org.avatar.address,
+        [testSetup.stateManager.address],
+        [testSetup.stateManagerParams.paramsHash], [permissions], "metaData"
+    );
+    return testSetup;
+};
+contract('StateManager', accounts => {
+
+    it("setParameters", async function () {
+        var stateManager = await StateManager.new();
+        var params = await setupStateManagerParams(stateManager);
+        var parameters = await stateManager.parameters(params.paramsHash);
+        assert.equal(parameters[1], params.votingMachine.absoluteVote.address);
+    });
+
+    it("proposeStateChange log", async function () {
+        var testSetup = await setup(accounts);
+        var tx = await testSetup.stateManager.proposeStateChange(
+                testSetup.org.avatar.address,
+                "description-hash",
+                "test-state-name",
+                "test-state-data"
+            );
+        assert.equal(tx.logs.length, 1);
+        assert.equal(tx.logs[0].event, "NewStateProposal");
+        assert.equal(await helpers.getValueFromLogs(tx, '_avatar', 0), testSetup.org.avatar.address, "Wrong log: _avatar");
+        assert.equal(await helpers.getValueFromLogs(tx, '_intVoteInterface', 0), testSetup.stateManagerParams.votingMachine.absoluteVote.address, "Wrong log: _intVoteInterface");
+        assert.equal(await helpers.getValueFromLogs(tx, '_descriptionHash', 15), "description-hash", "Wrong log: _stateDescription");
+    });
+
+    it("execute proposeStateChange", async function () {
+        var testSetup = await setup(accounts);
+        var tx = await testSetup.stateManager.proposeStateChange(
+            testSetup.org.avatar.address,
+            web3.utils.asciiToHex("description"),
+            "test-state-name",
+            "test-state-data"
+        );
+        //Vote with reputation to trigger execution
+        var proposalId = await helpers.getValueFromLogs(tx, '_proposalId', 1);
+        await testSetup.stateManagerParams.votingMachine.absoluteVote.vote(proposalId, 1, 0, helpers.NULL_ADDRESS, { from: accounts[2] });
+        var organizationProposal = await testSetup.stateManager.stateProposals(testSetup.org.avatar.address, proposalId);
+        assert.notEqual(organizationProposal[8], 0);//executionTime
+        // TODO check that state changed
+        assert.equal(await testSetup.stateManager.states(testSetup.org.avatar.address, "test-state-name"), "test-state-data")
+    });
+ 
+    it("call execute should revert if not from voting machine", async function () {
+        var testSetup = await setup(accounts);
+        var tx = await testSetup.stateManager.proposeStateChange(testSetup.org.avatar.address,
+            web3.utils.asciiToHex("description"),
+            "test-state-name",
+            "test-state-data"
+        );
+        //Account with reputation try to trigger execution
+        var proposalId = await helpers.getValueFromLogs(tx, '_proposalId', 1);
+        try {
+            await testSetup.stateManager.executeProposal(proposalId, 1);
+            assert(false, 'only voting machine can call execute');
+        } catch (ex) {
+            helpers.assertVMException(ex);
+        }
+    });
+});


### PR DESCRIPTION
Hey all,

I just started playing around with creating a "state management" universal scheme. The idea is based on the project I worked on at ETHBoston, a [Naive State DAO](https://devpost.com/software/naive-state-dao) that manages its own UI.

The idea is pretty simple: give DAOs the ability to endorse and name bits of data, like mission statements, codes of conduct, partnership agreements, UI elements, and so on. Eventually, DAOs could use this scheme or similar ones to manage any kind of product development or collaborative writing/editing/art via iteration (A/B tests, branching, etc.).

In the code right now, the state is just:
```
mapping(address=>mapping(string=>string)) public states;
```
in the universal scheme StateManager contract.

**I would love to get some feedback on the code and idea here.** Is this at all what we're looking for in contributions to Arc? What should I change and improve?

If this is workable, I'm happy to work next on a simple implementation for Alchemy.