### PR TITLE
SchemeRegistrar : remove and register in the same proposal

### DIFF
--- a/contracts/universalSchemes/SchemeRegistrar.sol
+++ b/contracts/universalSchemes/SchemeRegistrar.sol
@@ -10,22 +10,15 @@ import "../votingMachines/VotingMachineCallbacks.sol";
  * @title A registrar for Schemes for organizations
  * @dev The SchemeRegistrar is used for registering and unregistering schemes at organizations
  */
-
 contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExecuteInterface {
     event NewSchemeProposal(
         address indexed _avatar,
         bytes32 indexed _proposalId,
         address indexed _intVoteInterface,
-        address _scheme,
+        address _schemeToRegister,
+        address _schemeToUnRegister,
         bytes32 _parametersHash,
         bytes4 _permissions,
-        string _descriptionHash
-    );
-
-    event RemoveSchemeProposal(address indexed _avatar,
-        bytes32 indexed _proposalId,
-        address indexed _intVoteInterface,
-        address _scheme,
         string _descriptionHash
     );
 
@@ -34,8 +27,8 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
 
     // a SchemeProposal is a  proposal to add or remove a scheme to/from the an organization
     struct SchemeProposal {
-        address scheme; //
-        bool addScheme; // true: add a scheme, false: remove a scheme.
+        address schemeToRegister; //
+        address schemeToUnregister;
         bytes32 parametersHash;
         bytes4 permissions;
     }
@@ -45,8 +38,7 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
 
     // A mapping from hashes to parameters (use to store a particular configuration on the controller)
     struct Parameters {
-        bytes32 voteRegisterParams;
-        bytes32 voteRemoveParams;
+        bytes32 voteParams;
         IntVoteInterface intVote;
     }
 
@@ -60,7 +52,6 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
     function executeProposal(bytes32 _proposalId, int256 _param) external onlyVotingMachine(_proposalId) returns(bool) {
         Avatar avatar = proposalsInfo[msg.sender][_proposalId].avatar;
         SchemeProposal memory proposal = organizationsProposals[address(avatar)][_proposalId];
-        require(proposal.scheme != address(0));
         delete organizationsProposals[address(avatar)][_proposalId];
         emit ProposalDeleted(address(avatar), _proposalId);
         if (_param == 1) {
@@ -69,17 +60,17 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
             Controller controller = Controller(avatar.owner());
 
           // Add a scheme:
-            if (proposal.addScheme) {
+            if (proposal.schemeToRegister != address(0)) {
                 require(controller.registerScheme(
-                        proposal.scheme,
+                        proposal.schemeToRegister,
                         proposal.parametersHash,
                         proposal.permissions,
                         address(avatar))
                 );
             }
           // Remove a scheme:
-            if (!proposal.addScheme) {
-                require(controller.unregisterScheme(proposal.scheme, address(avatar)));
+            if (proposal.schemeToUnregister != address(0)) {
+                require(controller.unregisterScheme(proposal.schemeToUnregister, address(avatar)));
             }
         }
         emit ProposalExecuted(address(avatar), _proposalId, _param);
@@ -90,14 +81,12 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
     * @dev hash the parameters, save them if necessary, and return the hash value
     */
     function setParameters(
-        bytes32 _voteRegisterParams,
-        bytes32 _voteRemoveParams,
+        bytes32 _voteParams,
         IntVoteInterface _intVote
     ) public returns(bytes32)
     {
-        bytes32 paramsHash = getParametersHash(_voteRegisterParams, _voteRemoveParams, _intVote);
-        parameters[paramsHash].voteRegisterParams = _voteRegisterParams;
-        parameters[paramsHash].voteRemoveParams = _voteRemoveParams;
+        bytes32 paramsHash = getParametersHash(_voteParams, _intVote);
+        parameters[paramsHash].voteParams = _voteParams;
         parameters[paramsHash].intVote = _intVote;
         return paramsHash;
     }
@@ -105,16 +94,18 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
     /**
     * @dev create a proposal to register a scheme
     * @param _avatar the address of the organization the scheme will be registered for
-    * @param _scheme the address of the scheme to be registered
+    * @param _schemeToRegister the address of the scheme to be registered
+    * @param _schemeToUnRegister the address of the scheme to be unRegistered
     * @param _parametersHash a hash of the configuration of the _scheme
     * @param _permissions the permission of the scheme to be registered
     * @param _descriptionHash proposal's description hash
     * @return a proposal Id
     * @dev NB: not only proposes the vote, but also votes for it
     */
-    function proposeScheme(
+    function propose(
         Avatar _avatar,
-        address _scheme,
+        address _schemeToRegister,
+        address _schemeToUnRegister,
         bytes32 _parametersHash,
         bytes4 _permissions,
         string memory _descriptionHash
@@ -123,27 +114,30 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
     returns(bytes32)
     {
         // propose
-        require(_scheme != address(0), "scheme cannot be zero");
+        require(_schemeToRegister != address(0) || _schemeToUnRegister != address(0),
+        "scheme to register or unregister cannot be zero");
         Parameters memory controllerParams = parameters[getParametersFromController(_avatar)];
 
         bytes32 proposalId = controllerParams.intVote.propose(
             2,
-            controllerParams.voteRegisterParams,
+            controllerParams.voteParams,
             msg.sender,
             address(_avatar)
         );
 
         SchemeProposal memory proposal = SchemeProposal({
-            scheme: _scheme,
+            schemeToRegister: _schemeToRegister,
+            schemeToUnregister: _schemeToUnRegister,
             parametersHash: _parametersHash,
-            addScheme: true,
             permissions: _permissions
         });
         emit NewSchemeProposal(
             address(_avatar),
             proposalId,
             address(controllerParams.intVote),
-            _scheme, _parametersHash,
+            _schemeToRegister,
+            _schemeToUnRegister,
+            _parametersHash,
             _permissions,
             _descriptionHash
         );
@@ -153,40 +147,14 @@ contract SchemeRegistrar is UniversalScheme, VotingMachineCallbacks, ProposalExe
             avatar:_avatar
         });
         return proposalId;
-    }
 
-    /**
-    * @dev propose to remove a scheme for a controller
-    * @param _avatar the address of the controller from which we want to remove a scheme
-    * @param _scheme the address of the scheme we want to remove
-    * @param _descriptionHash proposal description hash
-    * NB: not only registers the proposal, but also votes for it
-    */
-    function proposeToRemoveScheme(Avatar _avatar, address _scheme, string memory _descriptionHash)
-    public
-    returns(bytes32)
-    {
-        require(_scheme != address(0), "scheme cannot be zero");
-        bytes32 paramsHash = getParametersFromController(_avatar);
-        Parameters memory params = parameters[paramsHash];
-
-        IntVoteInterface intVote = params.intVote;
-        bytes32 proposalId = intVote.propose(2, params.voteRemoveParams, msg.sender, address(_avatar));
-        organizationsProposals[address(_avatar)][proposalId].scheme = _scheme;
-        emit RemoveSchemeProposal(address(_avatar), proposalId, address(intVote), _scheme, _descriptionHash);
-        proposalsInfo[address(params.intVote)][proposalId] = ProposalInfo({
-            blockNumber:block.number,
-            avatar:_avatar
-        });
-        return proposalId;
     }
 
     function getParametersHash(
-        bytes32 _voteRegisterParams,
-        bytes32 _voteRemoveParams,
+        bytes32 _voteParams,
         IntVoteInterface _intVote
     ) public pure returns(bytes32)
     {
-        return keccak256(abi.encodePacked(_voteRegisterParams, _voteRemoveParams, _intVote));
+        return keccak256(abi.encodePacked(_voteParams, _intVote));
     }
 }

--- a/migrations/2_deploy_organization.js
+++ b/migrations/2_deploy_organization.js
@@ -66,8 +66,8 @@ module.exports = async function(deployer) {
       // Voting parameters and schemes params:
       var voteParametersHash = await AbsoluteVoteInst.getParametersHash(votePrec, NULL_ADDRESS);
 
-      await schemeRegistrarInst.setParameters(voteParametersHash, voteParametersHash, AbsoluteVoteInst.address);
-      var schemeRegisterParams = await schemeRegistrarInst.getParametersHash(voteParametersHash, voteParametersHash, AbsoluteVoteInst.address);
+      await schemeRegistrarInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
+      var schemeRegisterParams = await schemeRegistrarInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address);
       await globalConstraintRegistrarInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);
       var schemeGCRegisterParams = await globalConstraintRegistrarInst.getParametersHash(voteParametersHash, AbsoluteVoteInst.address);
       await upgradeSchemeInst.setParameters(voteParametersHash, AbsoluteVoteInst.address);


### PR DESCRIPTION
Enable remove and register scheme in the same proposal. 
This become a need as we would like to enable editing scheme params for none universal schemes.
This pr emit the `voting params to remove ` - any how it is currently possible to "edit" scheme parameters with `voting params to register` . do we really need these set of params?  
