### PR TITLE
avatar : use _to.call.value instead of transfer

### DIFF
--- a/contracts/controller/Avatar.sol
+++ b/contracts/controller/Avatar.sol
@@ -66,7 +66,9 @@ contract Avatar is Ownable {
     * @return bool which represents success
     */
     function sendEther(uint256 _amountInWei, address payable _to) public onlyOwner returns(bool) {
-        _to.transfer(_amountInWei);
+       // solhint-disable-next-line avoid-call-value
+        (bool success, ) = _to.call.value(_amountInWei)("");
+        require(success, "sendEther failed.");
         emit SendEther(_amountInWei, _to);
         return true;
     }


### PR DESCRIPTION
this will enable transfer eth to a contract , regardless of the gas restriction , which is in the transfer function.