### PR TITLE
Support GSMC factory no whitelist and ETH disabled

### DIFF
--- a/contracts/schemes/SimpleSchemeConstraints.sol
+++ b/contracts/schemes/SimpleSchemeConstraints.sol
@@ -9,6 +9,7 @@ contract SimpleSchemeConstraints is SchemeConstraints {
 
     mapping(address=>bool) public contractsWhiteListMap;
     bool public initialized;
+    bool public enableWhitelisting;
     bool public enableSendEth;
 
     /* @dev initialize
@@ -29,6 +30,7 @@ contract SimpleSchemeConstraints is SchemeConstraints {
         contractsWhiteList = _contractsWhiteList;
         descriptionHash = _descriptionHash;
         enableSendEth = _enableSendEth;
+        enableWhitelisting = _contractsWhiteList.length > 0;
     }
 
     /*
@@ -47,7 +49,7 @@ contract SimpleSchemeConstraints is SchemeConstraints {
     returns(bool)
     {
         for (uint i = 0; i < _contractsToCall.length; i++) {
-            require(contractsWhiteListMap[_contractsToCall[i]], "contract not whitelisted");
+            require(!enableWhitelisting || contractsWhiteListMap[_contractsToCall[i]], "contract not whitelisted");
             if (!enableSendEth) {
                 require(_values[i] == 0, "sending eth is not allowed");
             }
@@ -70,7 +72,7 @@ contract SimpleSchemeConstraints is SchemeConstraints {
     returns(bool)
     {
         for (uint i = 0; i < _contractsToCall.length; i++) {
-            require(contractsWhiteListMap[_contractsToCall[i]], "contract not whitelisted");
+            require(!enableWhitelisting || contractsWhiteListMap[_contractsToCall[i]], "contract not whitelisted");
             if (!enableSendEth) {
                 require(_values[i] == 0, "sending eth is not allowed");
             }

--- a/contracts/utils/GenericSchemeMultiCallFactory.sol
+++ b/contracts/utils/GenericSchemeMultiCallFactory.sol
@@ -28,7 +28,7 @@ contract GenericSchemeMultiCallFactory {
         require(_voteParamsType < 4, "Vote params type specified does not exist");
         GenericSchemeMultiCall genericSchemeMultiCall = new GenericSchemeMultiCall();
         address simpleSchemeConstraints;
-        if (_contractsWhiteList.length > 0) {
+        if (_contractsWhiteList.length > 0 || !_enableSendEth) {
             simpleSchemeConstraints = address(new SimpleSchemeConstraints());
             SimpleSchemeConstraints(simpleSchemeConstraints)
             .initialize(_contractsWhiteList, _descriptionHash, _enableSendEth);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.1-rc.56",
+  "version": "0.0.1-rc.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15218,7 +15218,7 @@
               }
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e",
               "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "dev": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daostack/arc",
-  "version": "0.0.1-rc.56",
+  "version": "0.0.1-rc.57",
   "description": "A platform for building DAOs",
   "files": [
     "contracts/",

--- a/test/genericschememulticallfactory.js
+++ b/test/genericschememulticallfactory.js
@@ -124,4 +124,59 @@ contract('genericSchemeMultiCallFactory', function(accounts) {
 
   });
 
+  it('initialize - sendEth disabled', async () => {
+    let testSetup = await setup();
+    let votingMachine = await helpers.setupGenesisProtocol(accounts,helpers.SOME_ADDRESS,0,helpers.NULL_ADDRESS);
+
+    for (let i=0; i < 4; i++) {
+      let address = await testSetup.genericSchemeMultiCallFactory.createGenericSchemeMultiCallSimple.call(
+        helpers.SOME_ADDRESS,
+        votingMachine.genesisProtocol.address,
+        i,
+        (i === 0 ? params[0] : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        helpers.NULL_ADDRESS,
+        (i === 0 ? [helpers.SOME_ADDRESS] : []),
+        false,
+        '0x0'
+      );
+
+      await testSetup.genericSchemeMultiCallFactory.createGenericSchemeMultiCallSimple(
+        helpers.SOME_ADDRESS,
+        votingMachine.genesisProtocol.address,
+        i,
+        (i === 0 ? params[0] : [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        helpers.NULL_ADDRESS,
+        (i === 0 ? [helpers.SOME_ADDRESS] : []),
+        false,
+        '0x0'
+      );
+
+      let genericSchemeMultiCall = await GenericSchemeMultiCall.at(address);
+      assert.equal(await genericSchemeMultiCall.avatar(), helpers.SOME_ADDRESS);
+      assert.equal(await genericSchemeMultiCall.votingMachine(), votingMachine.genesisProtocol.address);
+      assert.equal(
+        await genericSchemeMultiCall.voteParams(),
+        await votingMachine.genesisProtocol.getParametersHash(params[i], helpers.NULL_ADDRESS)
+      );
+      assert.notEqual(await genericSchemeMultiCall.schemeConstraints(), helpers.NULL_ADDRESS);
+    }
+
+    try {
+      await testSetup.genericSchemeMultiCallFactory.createGenericSchemeMultiCallSimple(
+        helpers.SOME_ADDRESS,
+        votingMachine.genesisProtocol.address,
+        4,
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        helpers.NULL_ADDRESS,
+        [],
+        true,
+        '0x0'
+      );
+      assert(false, "Vote params type specified does not exist");
+    } catch(error) {
+      helpers.assertVMException(error);
+    }
+
+  });
+
 });


### PR DESCRIPTION
Allow deploying GenericSchemeMultiCall from the factory with no whitelist requirements and eth sending disabled.